### PR TITLE
fix(ci): run ci workflows only on PRs

### DIFF
--- a/.github/workflows/event-bus-core-ci.yml
+++ b/.github/workflows/event-bus-core-ci.yml
@@ -2,11 +2,6 @@
 
 name: CI - @web-loom/event-bus-core
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'packages/event-bus-core/**'
   pull_request:
     branches:
       - main

--- a/.github/workflows/mvvm-core-ci.yml
+++ b/.github/workflows/mvvm-core-ci.yml
@@ -2,11 +2,6 @@
 
 name: CI - @web-loom/mvvm-core
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'packages/mvvm-core/**'
   pull_request:
     branches:
       - main

--- a/.github/workflows/query-core-ci.yml
+++ b/.github/workflows/query-core-ci.yml
@@ -2,11 +2,6 @@
 
 name: CI - @web-loom/query-core
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'packages/query-core/**'
   pull_request:
     branches:
       - main

--- a/.github/workflows/store-core-ci.yml
+++ b/.github/workflows/store-core-ci.yml
@@ -2,11 +2,6 @@
 
 name: CI - @web-loom/store-core
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'packages/store-core/**'
   pull_request:
     branches:
       - main


### PR DESCRIPTION
Updated CI workflow files to only trigger on pull requests to the main branch. This avoids redundant builds and tests when merging to main.