### PR TITLE
feat(design-core): Implement CSS token generation and export

### DIFF
--- a/packages/design-core/package.json
+++ b/packages/design-core/package.json
@@ -7,7 +7,8 @@
   "version": "0.0.3",
   "type": "module",
   "files": [
-    "dist"
+    "dist",
+    "src/css"
   ],
   "main": "./dist/design-core.umd.js",
   "module": "./dist/design-core.es.js",
@@ -17,6 +18,11 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/design-core.es.js",
       "require": "./dist/design-core.umd.js"
+    },
+    "./css/*": {
+      "import": "./src/css/*.css",
+      "style": "./src/css/*.css",
+      "default": "./src/css/*.css"
     }
   },
   "keywords": [
@@ -32,8 +38,9 @@
     "dashboard"
   ],
   "scripts": {
-    "dev": "vite build --watch",
-    "build": "vite build",
+    "generate:css": "node scripts/generate-css.cjs",
+    "dev": "npm run generate:css && npx vite build --watch",
+    "build": "npm run generate:css && npx vite build",
     "test": "vitest --watch=false",
     "test:watch": "vitest --watch",
     "test:coverage": "vitest run --coverage",

--- a/packages/design-core/scripts/generate-css.cjs
+++ b/packages/design-core/scripts/generate-css.cjs
@@ -1,0 +1,149 @@
+const fs = require('fs');
+const path = require('path');
+
+const tokensDir = path.join(__dirname, '../src/tokens');
+const outputDir = path.join(__dirname, '../src/css');
+
+function pathToCssVarName(tokenPath) {
+  return `--${tokenPath.join('-')}`;
+}
+
+// fileTokensRoot here is actually allMergedTokens
+function processTokenValue(value, allMergedTokens, currentTokenPathForLogging = []) {
+  if (typeof value !== 'string') {
+    return value;
+  }
+
+  const referenceRegex = /\{([^}]+?\.value)\}/g; // Matches {path.to.token.value}
+
+  let processedValue = value.replace(referenceRegex, (match, refString) => {
+    const refPathArray = refString.substring(0, refString.length - '.value'.length).split('.');
+
+    let resolvedNode = allMergedTokens; // Start resolution from the root of all merged tokens
+    for (const key of refPathArray) {
+      if (resolvedNode && typeof resolvedNode === 'object' && key in resolvedNode) {
+        resolvedNode = resolvedNode[key];
+      } else {
+        console.warn(`[Token Script] Warning for token ${pathToCssVarName(currentTokenPathForLogging)}: Reference path part "${key}" in "${refPathArray.join('.')}" not found in merged tokens. Raw segment: ${match}`);
+        return match; // Return original match if path is broken
+      }
+    }
+
+    if (resolvedNode && typeof resolvedNode === 'object' && 'value' in resolvedNode) {
+      // Recursively process the resolved value
+      return processTokenValue(resolvedNode.value, allMergedTokens, refPathArray);
+    } else {
+      console.warn(`[Token Script] Warning for token ${pathToCssVarName(currentTokenPathForLogging)}: Reference "${match}" resolved, but not to a token with a 'value' key. Path: ${refPathArray.join('.')}.`);
+      return match; // Return original match
+    }
+  });
+
+  const cssVariableRegex = /\{([^}]+?)\}/g;
+  processedValue = processedValue.replace(cssVariableRegex, (match, refString) => {
+    let pathArrayToConvert;
+    if (refString.endsWith('.value')) {
+        pathArrayToConvert = refString.substring(0, refString.length - '.value'.length).split('.');
+    } else {
+        pathArrayToConvert = refString.split('.');
+    }
+    return `var(${pathToCssVarName(pathArrayToConvert)})`;
+  });
+
+  return processedValue;
+}
+
+// tokenObj is a part of the potentially larger allMergedTokens structure
+// currentPath is the path from the root of tokenObj to the current node being processed
+// allMergedTokens is the global object of all tokens for reference resolution
+function generateCssVariables(tokenObj, currentPath = [], allMergedTokens) {
+  let cssVariables = [];
+  for (const key in tokenObj) {
+    if (!tokenObj.hasOwnProperty(key)) continue;
+
+    const newPath = [...currentPath, key]; // This path is relative to the starting tokenObj for this file
+    const valueNode = tokenObj[key];
+
+    if (typeof valueNode === 'object' && valueNode !== null) {
+      if ('value' in valueNode) {
+        // newPath here is the correct path for the CSS variable name from the file's root key
+        const varName = pathToCssVarName(newPath);
+        // currentTokenPathForLogging (newPath) is also used for logging within processTokenValue
+        const varValue = processTokenValue(valueNode.value, allMergedTokens, newPath);
+        cssVariables.push(`  ${varName}: ${varValue};`);
+      } else {
+        // Pass newPath for CSS var name construction, and allMergedTokens for reference resolution
+        cssVariables = cssVariables.concat(generateCssVariables(valueNode, newPath, allMergedTokens));
+      }
+    }
+  }
+  return cssVariables;
+}
+
+// Basic deep merge function
+function mergeDeep(...objects) {
+  const isObject = obj => obj && typeof obj === 'object' && !Array.isArray(obj);
+  return objects.reduce((prev, obj) => {
+    Object.keys(obj).forEach(key => {
+      const pVal = prev[key];
+      const oVal = obj[key];
+      if (isObject(pVal) && isObject(oVal)) {
+        prev[key] = mergeDeep(pVal, oVal);
+      } else {
+        prev[key] = oVal;
+      }
+    });
+    return prev;
+  }, {});
+}
+
+function main() {
+  if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir, { recursive: true });
+  }
+
+  const tokenFiles = fs.readdirSync(tokensDir).filter(file => file.endsWith('.json'));
+
+  // 1. Load all token files into a single merged object
+  let allMergedTokens = {};
+  tokenFiles.forEach(file => {
+    const filePath = path.join(tokensDir, file);
+    const fileContent = fs.readFileSync(filePath, 'utf-8');
+    try {
+      const tokensInFile = JSON.parse(fileContent);
+      allMergedTokens = mergeDeep(allMergedTokens, tokensInFile);
+    } catch (e) {
+      console.error(`Error parsing JSON from file ${file}: ${e.message}`);
+    }
+  });
+
+  // 2. Generate CSS for each file, using the merged tokens for reference resolution
+  tokenFiles.forEach(file => {
+    const filePath = path.join(tokensDir, file);
+    const fileContent = fs.readFileSync(filePath, 'utf-8');
+    let tokensInFile;
+    try {
+      tokensInFile = JSON.parse(fileContent);
+    } catch (e) {
+      // Already logged in the merge step, skip file if unparseable
+      return;
+    }
+
+    const baseName = path.basename(file, '.json');
+
+    // `generateCssVariables` needs to know the structure of the *current file* to create variable names correctly,
+    // but `processTokenValue` needs *all* tokens to resolve references.
+    // The `currentPath` in `generateCssVariables` starts from the root keys of `tokensInFile`.
+    // For example, if colors.json is {"color": {...}}, path starts with "color".
+    const cssVariables = generateCssVariables(tokensInFile, [], allMergedTokens);
+
+    if (cssVariables.length > 0) {
+      const cssContent = `:root {\n${cssVariables.join('\n')}\n}\n`;
+      fs.writeFileSync(path.join(outputDir, `${baseName}.css`), cssContent);
+      console.log(`Generated ${baseName}.css`);
+    } else {
+      console.log(`No variables generated for ${baseName}.css.`);
+    }
+  });
+}
+
+main();

--- a/packages/design-core/src/css/borders.css
+++ b/packages/design-core/src/css/borders.css
@@ -1,0 +1,9 @@
+:root {
+  --border-width-1: 1px;
+  --border-width-2: 2px;
+  --border-width-4: 4px;
+  --border-style-solid: solid;
+  --border-style-dashed: dashed;
+  --border-style-dotted: dotted;
+  --border-style-none: none;
+}

--- a/packages/design-core/src/css/breakpoints.css
+++ b/packages/design-core/src/css/breakpoints.css
@@ -1,0 +1,10 @@
+:root {
+  --breakpoint-xs: 0px;
+  --breakpoint-sm: 640px;
+  --breakpoint-md: 768px;
+  --breakpoint-lg: 1024px;
+  --breakpoint-xl: 1280px;
+  --breakpoint-2xl: 1536px;
+  --breakpoint-orientation-portrait: (orientation: portrait);
+  --breakpoint-orientation-landscape: (orientation: landscape);
+}

--- a/packages/design-core/src/css/colors.css
+++ b/packages/design-core/src/css/colors.css
@@ -1,0 +1,28 @@
+:root {
+  --color-base-primary: #1E40AF;
+  --color-base-secondary: #64748B;
+  --color-base-success: #10B981;
+  --color-base-warning: #F59E0B;
+  --color-base-danger: #EF4444;
+  --color-neutral-black: #000000;
+  --color-neutral-white: #FFFFFF;
+  --color-neutral-gray-50: #F9FAFB;
+  --color-neutral-gray-100: #F3F4F6;
+  --color-neutral-gray-200: #E5E7EB;
+  --color-neutral-gray-300: #D1D5DB;
+  --color-neutral-gray-400: #9CA3AF;
+  --color-neutral-gray-500: #6B7280;
+  --color-neutral-gray-600: #4B5563;
+  --color-neutral-gray-700: #374151;
+  --color-neutral-gray-800: #1F2937;
+  --color-neutral-gray-900: #111827;
+  --color-themed-light-background: #FFFFFF;
+  --color-themed-light-text: #000000;
+  --color-themed-dark-background: var(--color-neutral-900);
+  --color-themed-dark-text: #FFFFFF;
+  --color-themed-high-contrast-background: #000000;
+  --color-themed-high-contrast-text: #FFFFFF;
+  --color-alpha-primary-50: rgba(30, 64, 175, 0.5);
+  --color-alpha-primary-100: rgba(30, 64, 175, 1);
+  --color-alpha-black-50: rgba(0, 0, 0, 0.5);
+}

--- a/packages/design-core/src/css/cursor-styles.css
+++ b/packages/design-core/src/css/cursor-styles.css
@@ -1,0 +1,11 @@
+:root {
+  --cursor-auto: auto;
+  --cursor-default: default;
+  --cursor-pointer: pointer;
+  --cursor-wait: wait;
+  --cursor-text: text;
+  --cursor-move: move;
+  --cursor-not-allowed: not-allowed;
+  --cursor-grab: grab;
+  --cursor-grabbing: grabbing;
+}

--- a/packages/design-core/src/css/focus-rings.css
+++ b/packages/design-core/src/css/focus-rings.css
@@ -1,0 +1,12 @@
+:root {
+  --focusRing-color-default: #1E40AF;
+  --focusRing-color-error: #EF4444;
+  --focusRing-offset-none: 0px;
+  --focusRing-offset-sm: 1px;
+  --focusRing-offset-md: 2px;
+  --focusRing-width-sm: 1px;
+  --focusRing-width-md: 2px;
+  --focusRing-width-lg: 3px;
+  --focusRing-default: 2px solid #1E40AF;
+  --focusRing-error: 2px solid #EF4444;
+}

--- a/packages/design-core/src/css/gradients.css
+++ b/packages/design-core/src/css/gradients.css
@@ -1,0 +1,6 @@
+:root {
+  --gradient-primary-to-secondary: linear-gradient(to right, #1E40AF, #64748B);
+  --gradient-success-to-primary: linear-gradient(to right, #10B981, #1E40AF);
+  --gradient-multicolor-diagonal: linear-gradient(to bottom right, #1E40AF, #EF4444, #F59E0B);
+  --gradient-radial-primary: radial-gradient(circle, #1E40AF, #FFFFFF);
+}

--- a/packages/design-core/src/css/opacity.css
+++ b/packages/design-core/src/css/opacity.css
@@ -1,0 +1,9 @@
+:root {
+  --opacity-0: 0;
+  --opacity-25: 0.25;
+  --opacity-50: 0.5;
+  --opacity-75: 0.75;
+  --opacity-100: 1;
+  --opacity-disabled: 0.5;
+  --opacity-muted: 0.75;
+}

--- a/packages/design-core/src/css/radii.css
+++ b/packages/design-core/src/css/radii.css
@@ -1,0 +1,6 @@
+:root {
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 16px;
+  --radius-full: 9999px;
+}

--- a/packages/design-core/src/css/shadows.css
+++ b/packages/design-core/src/css/shadows.css
@@ -1,0 +1,9 @@
+:root {
+  --shadow-xs: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+  --shadow-sm: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06);
+  --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+  --shadow-xl: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+  --shadow-inner: inset 0 2px 4px 0 rgba(0, 0, 0, 0.06);
+  --shadow-focus: 0 0 0 3px rgba(59, 130, 246, 0.5);
+}

--- a/packages/design-core/src/css/sizing.css
+++ b/packages/design-core/src/css/sizing.css
@@ -1,0 +1,29 @@
+:root {
+  --sizing-width-xs: 160px;
+  --sizing-width-sm: 240px;
+  --sizing-width-md: 320px;
+  --sizing-width-lg: 480px;
+  --sizing-width-xl: 640px;
+  --sizing-width-full: 100%;
+  --sizing-height-xs: 160px;
+  --sizing-height-sm: 240px;
+  --sizing-height-md: 320px;
+  --sizing-height-lg: 480px;
+  --sizing-height-xl: 640px;
+  --sizing-height-full: 100%;
+  --sizing-maxWidth-xs: 160px;
+  --sizing-maxWidth-sm: 240px;
+  --sizing-maxWidth-md: 320px;
+  --sizing-maxWidth-lg: 480px;
+  --sizing-maxWidth-xl: 640px;
+  --sizing-maxWidth-screen: 100vw;
+  --sizing-minHeight-xs: 160px;
+  --sizing-minHeight-sm: 240px;
+  --sizing-minHeight-md: 320px;
+  --sizing-minHeight-lg: 480px;
+  --sizing-minHeight-xl: 640px;
+  --sizing-minHeight-screen: 100vh;
+  --sizing-icon-sm: 16px;
+  --sizing-icon-md: 24px;
+  --sizing-icon-lg: 32px;
+}

--- a/packages/design-core/src/css/spacing.css
+++ b/packages/design-core/src/css/spacing.css
@@ -1,0 +1,20 @@
+:root {
+  --spacing-0: 0px;
+  --spacing-1: 4px;
+  --spacing-2: 8px;
+  --spacing-3: 12px;
+  --spacing-4: 16px;
+  --spacing-5: 20px;
+  --spacing-6: 24px;
+  --spacing-7: 28px;
+  --spacing-8: 32px;
+  --spacing-9: 36px;
+  --spacing-10: 40px;
+  --spacing-gutter: 16px;
+  --spacing-padding-sm: 8px;
+  --spacing-padding-md: 16px;
+  --spacing-padding-lg: 24px;
+  --spacing-margin-sm: 8px;
+  --spacing-margin-md: 16px;
+  --spacing-margin-lg: 24px;
+}

--- a/packages/design-core/src/css/timing.css
+++ b/packages/design-core/src/css/timing.css
@@ -1,0 +1,9 @@
+:root {
+  --timing-delay-none: 0ms;
+  --timing-delay-short: 100ms;
+  --timing-delay-medium: 200ms;
+  --timing-delay-long: 300ms;
+  --timing-duration-short: 100ms;
+  --timing-duration-medium: 250ms;
+  --timing-duration-long: 500ms;
+}

--- a/packages/design-core/src/css/transitions.css
+++ b/packages/design-core/src/css/transitions.css
@@ -1,0 +1,13 @@
+:root {
+  --transition-duration-fast: 150ms;
+  --transition-duration-medium: 300ms;
+  --transition-duration-slow: 500ms;
+  --transition-timingFunction-linear: linear;
+  --transition-timingFunction-ease-in: cubic-bezier(0.4, 0, 1, 1);
+  --transition-timingFunction-ease-out: cubic-bezier(0, 0, 0.2, 1);
+  --transition-timingFunction-ease-in-out: cubic-bezier(0.4, 0, 0.2, 1);
+  --transition-delay-none: 0ms;
+  --transition-delay-short: 100ms;
+  --transition-delay-long: 200ms;
+  --transition-motion-prefersReducedMotion: (prefers-reduced-motion: reduce);
+}

--- a/packages/design-core/src/css/typography.css
+++ b/packages/design-core/src/css/typography.css
@@ -1,0 +1,25 @@
+:root {
+  --typography-font-family-base: 'Inter', sans-serif;
+  --typography-font-family-heading: 'Poppins', sans-serif;
+  --typography-font-size-xs: 12px;
+  --typography-font-size-sm: 14px;
+  --typography-font-size-md: 16px;
+  --typography-font-size-lg: 18px;
+  --typography-font-size-xl: 20px;
+  --typography-font-size-2xl: 24px;
+  --typography-font-size-3xl: 30px;
+  --typography-font-weight-light: 300;
+  --typography-font-weight-regular: 400;
+  --typography-font-weight-medium: 500;
+  --typography-font-weight-bold: 700;
+  --typography-font-weight-extrabold: 800;
+  --typography-lineHeight-tight: 1.25;
+  --typography-lineHeight-normal: 1.5;
+  --typography-lineHeight-loose: 2;
+  --typography-letterSpacing-tight: -0.05em;
+  --typography-letterSpacing-normal: normal;
+  --typography-letterSpacing-wide: 0.05em;
+  --typography-textCase-uppercase: uppercase;
+  --typography-textCase-lowercase: lowercase;
+  --typography-textCase-capitalize: capitalize;
+}

--- a/packages/design-core/src/css/z-index.css
+++ b/packages/design-core/src/css/z-index.css
@@ -1,0 +1,10 @@
+:root {
+  --zIndex-0: 0;
+  --zIndex-10: 10;
+  --zIndex-20: 20;
+  --zIndex-30: 30;
+  --zIndex-40: 40;
+  --zIndex-50: 50;
+  --zIndex-auto: auto;
+  --zIndex-max: 9999;
+}


### PR DESCRIPTION
Adds a script to `packages/design-core` that converts JSON design tokens into individual CSS files containing CSS Custom Properties. These generated CSS files are located in `packages/design-core/src/css/`.

The script is integrated into the `build` and `dev` processes.

The `package.json` for `design-core` has been updated to:
- Include `src/css` in the `files` array for publishing.
- Export the generated CSS files under the `./css/*` path, allowing consumers to import them (e.g., `@web-loom/design-core/css/colors.css`).

The build process has been verified to generate both the CSS files and the standard JavaScript/TypeScript library outputs.