### PR TITLE
feat: Add CachedRestfulApiModel and ViewModel with QueryCore integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27920,6 +27920,7 @@
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -30113,7 +30114,7 @@
         "typescript": "~5.7.3",
         "vite": "^6.1.1",
         "vite-plugin-dts": "^3.9.1",
-        "vitest": "^3.1.4"
+        "vitest": "^3.2.4"
       }
     },
     "packages/mvvm-core/node_modules/@types/node": {
@@ -37539,7 +37540,7 @@
         "typescript": "~5.7.3",
         "vite": "^6.1.1",
         "vite-plugin-dts": "^3.9.1",
-        "vitest": "^3.1.4",
+        "vitest": "^3.2.4",
         "zod": "^3.25.67"
       },
       "dependencies": {
@@ -44658,7 +44659,7 @@
         "typescript": "~5.7.3",
         "vite": "^6.1.1",
         "vite-plugin-dts": "^3.9.1",
-        "vitest": "^3.1.4",
+        "vitest": "^3.2.4",
         "zod": "^3.25.67"
       },
       "dependencies": {

--- a/packages/mvvm-core/package.json
+++ b/packages/mvvm-core/package.json
@@ -41,7 +41,7 @@
     "typescript": "~5.7.3",
     "vite": "^6.1.1",
     "vite-plugin-dts": "^3.9.1",
-    "vitest": "^3.1.4"
+    "vitest": "^3.2.4"
   },
   "dependencies": {
     "rxjs": "^7.8.2",

--- a/packages/mvvm-core/src/index.ts
+++ b/packages/mvvm-core/src/index.ts
@@ -4,25 +4,35 @@ import { TodoItem } from './examples/models/TodoItem';
 import { TodoListViewModel } from './examples/viewmodels/TodoListViewModel';
 import { BaseModel } from './models/BaseModel';
 import { RestfulApiModel } from './models/RestfulApiModel';
+import { CachedRestfulApiModel } from './models/CachedRestfulApiModel'; // Added
 import { BaseViewModel } from './viewmodels/BaseViewModel';
 import { RestfulApiViewModel } from './viewmodels/RestfulApiViewModel';
+import { CachedRestfulApiViewModel } from './viewmodels/CachedRestfulApiViewModel'; // Added
 
 export {
   ObservableCollection,
   Command,
   BaseModel,
   RestfulApiModel,
+  CachedRestfulApiModel, // Added
   RestfulApiViewModel,
+  CachedRestfulApiViewModel, // Added
   BaseViewModel,
   // examples:
   TodoItem,
   TodoListViewModel,
 };
 
-export type { Fetcher } from './models/RestfulApiModel';
+export type { Fetcher, ExtractItemType as ExtractRestfulItemType } from './models/RestfulApiModel'; // Renamed ExtractItemType
+export type {
+  TCachedConstructorInput,
+  ExtractItemType as ExtractCachedItemType, // Renamed ExtractItemType
+} from './models/CachedRestfulApiModel';
 export type { ICommand } from './commands/Command';
 export type { IObservableCollection } from './collections/ObservableCollection';
 export type { IBaseModel } from './models/BaseModel';
+export type { IRestfulApiModel } from './models/RestfulApiModel';
+export type { ICachedRestfulApiModel } from './models/CachedRestfulApiModel';
 
 // Exports for Restful Todo Example
 export { FakeTodoApi } from './examples/api/FakeTodoApi';

--- a/packages/mvvm-core/src/models/CachedRestfulApiModel.test.ts
+++ b/packages/mvvm-core/src/models/CachedRestfulApiModel.test.ts
@@ -1,0 +1,305 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { z } from 'zod';
+import { CachedRestfulApiModel, TCachedConstructorInput } from './CachedRestfulApiModel';
+import QueryCore from '@packages/query-core'; // Actual import
+import { BehaviorSubject } from 'rxjs';
+
+// Mock QueryCore
+vi.mock('@packages/query-core', () => {
+  const actualQueryCore = vi.importActual('@packages/query-core');
+  return {
+    ...actualQueryCore, // Import and retain actual exports like EndpointState if needed directly in tests
+    default: vi.fn().mockImplementation(() => ({
+      subscribe: vi.fn(() => vi.fn()), // subscribe returns an unsubscribe function
+      refetch: vi.fn(() => Promise.resolve()),
+      invalidate: vi.fn(() => Promise.resolve()),
+      getState: vi.fn(() => ({
+        data: undefined,
+        isLoading: false,
+        isError: false,
+        error: undefined,
+        lastUpdated: undefined,
+      })),
+    })),
+  };
+});
+
+// Mock fetcher
+const mockFetcher = vi.fn();
+
+const TestSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+});
+type TestData = z.infer<typeof TestSchema>;
+
+const TestArraySchema = z.array(TestSchema);
+type TestArrayData = z.infer<typeof TestArraySchema>;
+
+describe('CachedRestfulApiModel', () => {
+  let mockQueryCoreInstance: QueryCore;
+  let model: CachedRestfulApiModel<TestData, typeof TestSchema>;
+  let arrayModel: CachedRestfulApiModel<TestArrayData, typeof TestArraySchema>;
+
+  const endpointKey = 'testEndpoint';
+  const baseUrl = 'https://api.example.com';
+  const endpoint = 'tests';
+
+  beforeEach(() => {
+    // Create a new mock instance for each test to reset call counts etc.
+    mockQueryCoreInstance = new QueryCore();
+    mockFetcher.mockClear(); // Clear fetcher mocks
+
+    const modelInput: TCachedConstructorInput<TestData, typeof TestSchema> = {
+      queryCore: mockQueryCoreInstance,
+      endpointKey,
+      schema: TestSchema,
+      fetcher: mockFetcher,
+      baseUrl,
+      endpoint,
+    };
+    model = new CachedRestfulApiModel(modelInput);
+
+    const arrayModelInput: TCachedConstructorInput<TestArrayData, typeof TestArraySchema> = {
+      queryCore: mockQueryCoreInstance,
+      endpointKey: `${endpointKey}Array`,
+      schema: TestArraySchema,
+      fetcher: mockFetcher,
+      baseUrl,
+      endpoint,
+    };
+    arrayModel = new CachedRestfulApiModel(arrayModelInput);
+  });
+
+  afterEach(() => {
+    model.dispose();
+    arrayModel.dispose();
+    vi.clearAllMocks(); // Clears all mocks including QueryCore constructor and its methods
+  });
+
+  it('should be instantiated', () => {
+    expect(model).toBeInstanceOf(CachedRestfulApiModel);
+    expect(mockQueryCoreInstance.subscribe).toHaveBeenCalledWith(endpointKey, expect.any(Function));
+  });
+
+  it('should call QueryCore.refetch on query()', async () => {
+    await model.query();
+    expect(mockQueryCoreInstance.refetch).toHaveBeenCalledWith(endpointKey, false);
+  });
+
+  it('should call QueryCore.refetch with forceRefetch true on query(true)', async () => {
+    await model.query(true);
+    expect(mockQueryCoreInstance.refetch).toHaveBeenCalledWith(endpointKey, true);
+  });
+
+  it('should update data$ when QueryCore subscription callback is invoked with new data', () => {
+    const testData: TestData = { id: '1', name: 'Test Item' };
+    let callbackFn: (state: any) => void = () => {};
+    // Capture the callback
+    (mockQueryCoreInstance.subscribe as vi.Mock).mockImplementationOnce((key, cb) => {
+      callbackFn = cb;
+      return vi.fn(); // unsubscribe
+    });
+
+    // Re-initialize model to capture the new subscribe mock
+    model = new CachedRestfulApiModel({
+      queryCore: mockQueryCoreInstance,
+      endpointKey,
+      schema: TestSchema,
+    });
+
+    callbackFn({ data: testData, isLoading: false, isError: false });
+    expect(model.data$.getValue()).toEqual(testData);
+  });
+
+  it('should update isLoading$ when QueryCore subscription callback is invoked', () => {
+    let callbackFn: (state: any) => void = () => {};
+    (mockQueryCoreInstance.subscribe as vi.Mock).mockImplementationOnce((key, cb) => {
+      callbackFn = cb;
+      return vi.fn();
+    });
+    model = new CachedRestfulApiModel({ queryCore: mockQueryCoreInstance, endpointKey, schema: TestSchema });
+
+    callbackFn({ data: null, isLoading: true, isError: false });
+    expect(model.isLoading$.getValue()).toBe(true);
+    callbackFn({ data: null, isLoading: false, isError: false });
+    expect(model.isLoading$.getValue()).toBe(false);
+  });
+
+  it('should update error$ when QueryCore subscription callback is invoked with an error', () => {
+    const testError = new Error('Test error');
+    let callbackFn: (state: any) => void = () => {};
+    (mockQueryCoreInstance.subscribe as vi.Mock).mockImplementationOnce((key, cb) => {
+      callbackFn = cb;
+      return vi.fn();
+    });
+    model = new CachedRestfulApiModel({ queryCore: mockQueryCoreInstance, endpointKey, schema: TestSchema });
+
+    callbackFn({ data: null, isLoading: false, isError: true, error: testError });
+    expect(model.error$.getValue()).toEqual(testError);
+  });
+
+   it('should validate data if schema validation is enabled (default)', () => {
+    const invalidData = { id: '1', name: 123 }; // name should be string
+    let callbackFn: (state: any) => void = () => {};
+    (mockQueryCoreInstance.subscribe as vi.Mock).mockImplementationOnce((key, cb) => {
+      callbackFn = cb;
+      return vi.fn();
+    });
+    model = new CachedRestfulApiModel({ queryCore: mockQueryCoreInstance, endpointKey, schema: TestSchema });
+
+    callbackFn({ data: invalidData, isLoading: false, isError: false });
+    expect(model.error$.getValue()).toBeInstanceOf(z.ZodError);
+    expect(model.data$.getValue()).toBeNull(); // Or stale data, depending on exact error handling
+  });
+
+
+  it('should not validate data if schema validation is disabled', () => {
+    const invalidData = { id: '1', name: 123 }; // name should be string
+    let callbackFn: (state: any) => void = () => {};
+    (mockQueryCoreInstance.subscribe as vi.Mock).mockImplementationOnce((key, cb) => {
+      callbackFn = cb;
+      return vi.fn();
+    });
+    const modelWithoutValidation = new CachedRestfulApiModel({
+      queryCore: mockQueryCoreInstance,
+      endpointKey,
+      schema: TestSchema,
+      validateSchema: false, // Disable validation
+    });
+
+    callbackFn({ data: invalidData, isLoading: false, isError: false });
+    expect(modelWithoutValidation.error$.getValue()).toBeNull();
+    expect(modelWithoutValidation.data$.getValue()).toEqual(invalidData);
+    modelWithoutValidation.dispose();
+   });
+
+
+  describe('CUD Operations', () => {
+    const itemToCreate: Partial<TestData> = { name: 'New Item' };
+    const createdItem: TestData = { id: 'genId1', name: 'New Item' };
+    const itemToUpdateId = 'existingId1';
+    const itemUpdatePayload: Partial<TestData> = { name: 'Updated Item' };
+    const updatedItem: TestData = { id: itemToUpdateId, name: 'Updated Item' };
+
+    beforeEach(() => {
+      // CUD operations require fetcher, baseUrl, endpoint
+      const fullInput: TCachedConstructorInput<TestData, typeof TestSchema> = {
+        queryCore: mockQueryCoreInstance,
+        endpointKey,
+        schema: TestSchema,
+        fetcher: mockFetcher,
+        baseUrl,
+        endpoint,
+      };
+      model = new CachedRestfulApiModel(fullInput); // Re-init model with fetcher for CUD
+    });
+
+    it('create() should call fetcher, invalidate and refetch QueryCore endpoint', async () => {
+      mockFetcher.mockResolvedValueOnce(createdItem);
+      const result = await model.create(itemToCreate);
+
+      expect(mockFetcher).toHaveBeenCalledWith(
+        `${baseUrl}/${endpoint}`,
+        expect.objectContaining({ method: 'POST', body: JSON.stringify(itemToCreate) }),
+      );
+      expect(result).toEqual(createdItem);
+      expect(mockQueryCoreInstance.invalidate).toHaveBeenCalledWith(endpointKey);
+      expect(mockQueryCoreInstance.refetch).toHaveBeenCalledWith(endpointKey, true);
+    });
+
+    it('update() should call fetcher, invalidate and refetch QueryCore endpoint', async () => {
+      mockFetcher.mockResolvedValueOnce(updatedItem);
+      const result = await model.update(itemToUpdateId, itemUpdatePayload);
+
+      expect(mockFetcher).toHaveBeenCalledWith(
+        `${baseUrl}/${endpoint}/${itemToUpdateId}`,
+        expect.objectContaining({ method: 'PUT', body: JSON.stringify(itemUpdatePayload) }),
+      );
+      expect(result).toEqual(updatedItem);
+      expect(mockQueryCoreInstance.invalidate).toHaveBeenCalledWith(endpointKey);
+      expect(mockQueryCoreInstance.refetch).toHaveBeenCalledWith(endpointKey, true);
+    });
+
+    it('delete() should call fetcher, invalidate and refetch QueryCore endpoint', async () => {
+      const itemIdToDelete = 'delId1';
+      mockFetcher.mockResolvedValueOnce(undefined); // Delete typically returns no content
+
+      await model.delete(itemIdToDelete);
+
+      expect(mockFetcher).toHaveBeenCalledWith(
+        `${baseUrl}/${endpoint}/${itemIdToDelete}`,
+        expect.objectContaining({ method: 'DELETE' }),
+      );
+      expect(mockQueryCoreInstance.invalidate).toHaveBeenCalledWith(endpointKey);
+      expect(mockQueryCoreInstance.refetch).toHaveBeenCalledWith(endpointKey, true);
+    });
+
+    it('create() with array payload for arrayModel', async () => {
+        const itemsToCreate: Partial<TestData>[] = [{ name: 'Item A' }, { name: 'Item B' }];
+        const createdItems: TestData[] = [
+            { id: 'genA', name: 'Item A' },
+            { id: 'genB', name: 'Item B' },
+        ];
+        // Mock fetcher to return individual items for each POST, then arrayModel combines them
+        mockFetcher.mockResolvedValueOnce(createdItems[0]); // For first item in payload
+        mockFetcher.mockResolvedValueOnce(createdItems[1]); // For second item in payload
+
+        const arrayModelInput: TCachedConstructorInput<TestArrayData, typeof TestArraySchema> = {
+            queryCore: mockQueryCoreInstance,
+            endpointKey: `${endpointKey}ArrayCreate`,
+            schema: TestArraySchema,
+            fetcher: mockFetcher,
+            baseUrl,
+            endpoint,
+        };
+        arrayModel = new CachedRestfulApiModel(arrayModelInput);
+
+
+        const result = await arrayModel.create(itemsToCreate);
+
+        expect(mockFetcher).toHaveBeenCalledTimes(itemsToCreate.length);
+        expect(mockFetcher).toHaveBeenCalledWith(
+            `${baseUrl}/${endpoint}`,
+            expect.objectContaining({ method: 'POST', body: JSON.stringify(itemsToCreate[0]) }),
+        );
+        expect(mockFetcher).toHaveBeenCalledWith(
+            `${baseUrl}/${endpoint}`,
+            expect.objectContaining({ method: 'POST', body: JSON.stringify(itemsToCreate[1]) }),
+        );
+        expect(result).toEqual(createdItems); // Expecting the combined array of created items
+        expect(mockQueryCoreInstance.invalidate).toHaveBeenCalledWith(`${endpointKey}ArrayCreate`);
+        expect(mockQueryCoreInstance.refetch).toHaveBeenCalledWith(`${endpointKey}ArrayCreate`, true);
+    });
+
+
+    it('should throw error if CUD operations are called without fetcher configured', async () => {
+        const modelWithoutFetcher = new CachedRestfulApiModel({
+            queryCore: mockQueryCoreInstance,
+            endpointKey: 'noFetcherEndpoint',
+            schema: TestSchema,
+            // No fetcher, baseUrl, endpoint
+        });
+
+        await expect(modelWithoutFetcher.create(itemToCreate)).rejects.toThrow('Fetcher not configured');
+        await expect(modelWithoutFetcher.update(itemToUpdateId, itemUpdatePayload)).rejects.toThrow('Fetcher not configured');
+        await expect(modelWithoutFetcher.delete(itemToUpdateId)).rejects.toThrow('Fetcher not configured');
+        modelWithoutFetcher.dispose();
+    });
+  });
+
+  it('dispose() should unsubscribe from QueryCore', () => {
+    const unsubscribeMock = vi.fn();
+    (mockQueryCoreInstance.subscribe as vi.Mock).mockReturnValueOnce(unsubscribeMock);
+
+    // Re-initialize model to capture the new subscribe mock that returns our unsubscribeMock
+    const freshModel = new CachedRestfulApiModel({
+      queryCore: mockQueryCoreInstance,
+      endpointKey,
+      schema: TestSchema,
+    });
+
+    freshModel.dispose();
+    expect(unsubscribeMock).toHaveBeenCalled();
+  });
+});

--- a/packages/mvvm-core/src/models/CachedRestfulApiModel.ts
+++ b/packages/mvvm-core/src/models/CachedRestfulApiModel.ts
@@ -1,0 +1,310 @@
+import { ZodSchema, z } from 'zod';
+import { BaseModel } from './BaseModel';
+import QueryCore, { EndpointState } from '@packages/query-core'; // Assuming QueryCore is available as a package
+
+// Helper for temporary ID generation (can be shared if used elsewhere)
+const tempIdPrefix = 'temp_';
+function generateTempId(): string {
+  return `${tempIdPrefix}${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
+}
+
+// Helper to manage item with ID (can be shared)
+interface ItemWithId {
+  id: string;
+  [key: string]: any;
+}
+
+// Helper type to extract the underlying type if T is an array, otherwise returns T
+export type ExtractItemType<T> = T extends (infer U)[] ? U : T;
+
+export type TCachedConstructorInput<TData, TSchema extends ZodSchema<TData>> = {
+  queryCore: QueryCore;
+  endpointKey: string; // Unique key for QueryCore to identify this data source
+  schema: TSchema;
+  initialData?: TData | null; // Optional initial data, QueryCore might hydrate this
+  // baseUrl and endpoint might still be needed for constructing specific URLs for CUD operations
+  // if QueryCore's fetcher is generic and needs the full URL.
+  // However, the primary fetch will be via queryCore.
+  // For CUD, we might need a separate mechanism or assume QueryCore handles it via specific fetchers.
+  // Let's assume for now that CUD operations also go through QueryCore or a configured fetcher within it.
+  // If direct fetch calls are needed for CUD, fetcher and baseUrl/endpoint would be required.
+  // For this iteration, we'll focus on QueryCore for data retrieval.
+  // CUD operations will need careful consideration on how they interact with QueryCore's caching.
+  // A simple approach is to have dedicated fetcher functions for CUD operations
+  // that QueryCore can call, or the model calls directly and then invalidates QueryCore's cache.
+
+  // For CUD operations that are not directly handled by a generic QueryCore query:
+  fetcher?: <TResponse = any>(url: string, options?: RequestInit) => Promise<TResponse>; // For CUD
+  baseUrl?: string; // For CUD
+  endpoint?: string; // For CUD (e.g., 'users')
+  validateSchema?: boolean;
+};
+
+/**
+ * @class CachedRestfulApiModel
+ * Extends BaseModel to provide capabilities for interacting with data sources via QueryCore.
+ * It manages data, loading states, and errors, leveraging QueryCore for caching and data fetching.
+ * @template TData The type of data managed by the model (e.g., User, User[]).
+ * @template TSchema The Zod schema type for validating the data.
+ */
+export class CachedRestfulApiModel<TData, TSchema extends ZodSchema<TData>> extends BaseModel<TData, TSchema> {
+  private readonly queryCore: QueryCore;
+  private readonly endpointKey: string;
+  private readonly _shouldValidateSchema: boolean;
+
+  // Optional members for CUD operations if not handled by QueryCore's primary query
+  private readonly fetcher?: <TResponse = any>(url: string, options?: RequestInit) => Promise<TResponse>;
+  private readonly baseUrl?: string;
+  private readonly endpoint?: string;
+
+  private unsubscribeFromQueryCore?: () => void;
+
+  constructor(input: TCachedConstructorInput<TData, TSchema>) {
+    const { queryCore, endpointKey, schema, initialData, fetcher, baseUrl, endpoint, validateSchema } = input;
+    super({ initialData: initialData || null, schema });
+
+    if (!queryCore || !endpointKey) {
+      throw new Error('CachedRestfulApiModel requires queryCore and endpointKey.');
+    }
+    this.queryCore = queryCore;
+    this.endpointKey = endpointKey;
+    this._shouldValidateSchema = validateSchema === undefined ? true : validateSchema;
+
+    // Store CUD related properties if provided
+    if (fetcher && baseUrl && endpoint) {
+      this.fetcher = fetcher;
+      this.baseUrl = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
+      this.endpoint = endpoint.startsWith('/') ? endpoint.slice(1) : endpoint;
+    } else if (fetcher || baseUrl || endpoint) {
+      // If some CUD params are provided but not all, it's a configuration issue.
+      console.warn(
+        'CachedRestfulApiModel: For CUD operations, fetcher, baseUrl, and endpoint must all be provided if one is provided. CUD operations might not work as expected.',
+      );
+    }
+
+    this.subscribeToQueryCore();
+  }
+
+  private subscribeToQueryCore(): void {
+    // Unsubscribe from any previous subscription
+    if (this.unsubscribeFromQueryCore) {
+      this.unsubscribeFromQueryCore();
+    }
+
+    this.unsubscribeFromQueryCore = this.queryCore.subscribe<TData>(
+      this.endpointKey,
+      (state: EndpointState<TData>) => {
+        this.setLoading(state.isLoading);
+        if (state.isError) {
+          this.setError(state.error);
+        } else {
+          this.clearError(); // Clear error if current state is not error
+        }
+
+        if (state.data !== undefined) {
+          if (this._shouldValidateSchema && this.schema) {
+            try {
+              const validatedData = this.schema.parse(state.data);
+              this.setData(validatedData);
+            } catch (validationError) {
+              this.setError(validationError);
+              // Potentially set data to null or keep stale data, depending on desired behavior
+              // For now, we set an error and the data might remain stale or become undefined.
+            }
+          } else {
+            this.setData(state.data);
+          }
+        } else if (!state.isLoading && !state.isError) {
+          // If data is undefined, not loading, and no error, it implies empty or no data.
+          // This could be initial state or after an invalidation.
+          // BaseModel's setData(null) handles this.
+          this.setData(null);
+        }
+        // If state.data is undefined but it's loading or error, data$ shouldn't be nulled out
+        // as it might hold stale data that's preferred over null during loading/error.
+        // BaseModel's setData handles the BehaviorSubject update.
+      },
+    );
+
+    // Optionally, trigger an initial fetch if the data is stale or not present,
+    // QueryCore's subscribe method itself might handle this based on its internal logic.
+    // If QueryCore's subscribe doesn't auto-fetch, we might need:
+    // this.queryCore.refetch(this.endpointKey);
+    // However, QueryCore's design is that subscription itself triggers fetch if stale/empty.
+  }
+
+  /**
+   * Initiates a data fetch (or refetch) using QueryCore.
+   * QueryCore handles the actual fetching, caching, and state updates.
+   * This model subscribes to QueryCore's state updates.
+   * @param forceRefetch Optionally force QueryCore to refetch regardless of cache status.
+   */
+  public async query(forceRefetch = false): Promise<void> {
+    try {
+      // setLoading and clearError will be handled by the QueryCore subscription callback
+      await this.queryCore.refetch(this.endpointKey, forceRefetch);
+      // The actual data update, loading, and error states are managed via the subscription to QueryCore.
+    } catch (error) {
+      // This catch block might be redundant if QueryCore's refetch itself doesn't throw
+      // but rather updates its state with the error, which our subscription picks up.
+      // If QueryCore.refetch can throw for reasons other than data fetching issues (e.g., config error),
+      // then this catch is relevant.
+      this.setError(error); // Ensure model's error state is set.
+      throw error; // Re-throw to allow caller to handle
+    }
+  }
+
+  private getCudUrl(id?: string): string {
+    if (!this.baseUrl || !this.endpoint) {
+      throw new Error('CUD operations require baseUrl and endpoint to be configured.');
+    }
+    if (id) {
+      return `${this.baseUrl}/${this.endpoint}/${id}`;
+    }
+    return `${this.baseUrl}/${this.endpoint}`;
+  }
+
+  // CUD operations:
+  // These will perform direct API calls and then interact with QueryCore
+  // to ensure cache consistency (e.g., by invalidating or updating the cache).
+
+  /**
+   * Creates a new resource.
+   * After a successful creation, it invalidates the QueryCore cache for this endpointKey
+   * to ensure fresh data is fetched on the next query.
+   * Optimistic updates can be implemented similarly to RestfulApiModel if desired.
+   * @param payload The data for the new resource.
+   * @returns A promise that resolves with the created item.
+   */
+  public async create(
+    payload: Partial<ExtractItemType<TData>> | Partial<ExtractItemType<TData>>[],
+  ): Promise<ExtractItemType<TData> | ExtractItemType<TData>[] | undefined> {
+    if (!this.fetcher) {
+      throw new Error('Fetcher not configured for CUD operations.');
+    }
+    this.setLoading(true);
+    this.clearError();
+
+    // Basic implementation without optimistic updates for now.
+    // For optimistic updates, refer to RestfulApiModel's create method.
+    try {
+      const isPayloadArray = Array.isArray(payload);
+      let result: ExtractItemType<TData> | ExtractItemType<TData>[] | undefined;
+
+      if (isPayloadArray) {
+        const results = await Promise.all(
+          (payload as Partial<ExtractItemType<TData>>[]).map((item) =>
+            this.fetcher!(this.getCudUrl(), {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify(item),
+            }),
+          ),
+        );
+        // Assuming the fetcher returns the created item(s) parsed.
+        // And schema validation for the response.
+        result = this._shouldValidateSchema
+          ? z.array(this.schema.element ? (this.schema as z.ZodArray<any>).element : this.schema).parse(results) // Heuristic
+          : results;
+      } else {
+        const singleResult = await this.fetcher!(this.getCudUrl(), {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
+        result = this._shouldValidateSchema
+          ? (this.schema.element ? (this.schema as z.ZodArray<any>).element : this.schema).parse(singleResult) // Heuristic
+          : singleResult;
+      }
+
+      await this.queryCore.invalidate(this.endpointKey); // Invalidate cache
+      await this.queryCore.refetch(this.endpointKey, true); // Refetch to update the model's data via subscription
+      return result;
+    } catch (err) {
+      this.setError(err);
+      throw err;
+    } finally {
+      this.setLoading(false); // Handled by queryCore subscription eventually, but good for immediate feedback
+    }
+  }
+
+  /**
+   * Updates an existing resource.
+   * After a successful update, it invalidates the QueryCore cache for this endpointKey.
+   * @param id The ID of the resource to update.
+   * @param payload The partial data to update the resource with.
+   * @returns A promise that resolves with the updated item.
+   */
+  public async update(
+    id: string,
+    payload: Partial<ExtractItemType<TData>>,
+  ): Promise<ExtractItemType<TData> | undefined> {
+    if (!this.fetcher) {
+      throw new Error('Fetcher not configured for CUD operations.');
+    }
+    this.setLoading(true);
+    this.clearError();
+    try {
+      const result = await this.fetcher!(this.getCudUrl(id), {
+        method: 'PUT', // Or 'PATCH'
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+
+      const validatedResult = this._shouldValidateSchema
+        ? (this.schema.element ? (this.schema as z.ZodArray<any>).element : this.schema).parse(result) // Heuristic
+        : result;
+
+      await this.queryCore.invalidate(this.endpointKey);
+      await this.queryCore.refetch(this.endpointKey, true);
+      return validatedResult;
+    } catch (err) {
+      this.setError(err);
+      throw err;
+    } finally {
+      this.setLoading(false);
+    }
+  }
+
+  /**
+   * Deletes a resource.
+   * After a successful deletion, it invalidates the QueryCore cache for this endpointKey.
+   * @param id The ID of the resource to delete.
+   * @returns A promise that resolves when the deletion is complete.
+   */
+  public async delete(id: string): Promise<void> {
+    if (!this.fetcher) {
+      throw new Error('Fetcher not configured for CUD operations.');
+    }
+    this.setLoading(true);
+    this.clearError();
+    try {
+      await this.fetcher!(this.getCudUrl(id), { method: 'DELETE' });
+      await this.queryCore.invalidate(this.endpointKey);
+      await this.queryCore.refetch(this.endpointKey, true);
+    } catch (err) {
+      this.setError(err);
+      throw err;
+    } finally {
+      this.setLoading(false);
+    }
+  }
+
+  public dispose(): void {
+    if (this.unsubscribeFromQueryCore) {
+      this.unsubscribeFromQueryCore();
+      this.unsubscribeFromQueryCore = undefined;
+    }
+    super.dispose();
+  }
+}
+
+// Interface for CachedRestfulApiModel
+export interface ICachedRestfulApiModel<TData, TSchema extends ZodSchema<TData>> extends BaseModel<TData, TSchema> {
+  query(forceRefetch?: boolean): Promise<void>;
+  create(
+    payload: Partial<ExtractItemType<TData>> | Partial<ExtractItemType<TData>>[],
+  ): Promise<ExtractItemType<TData> | ExtractItemType<TData>[] | undefined>;
+  update(id: string, payload: Partial<ExtractItemType<TData>>): Promise<ExtractItemType<TData> | undefined>;
+  delete(id: string): Promise<void>;
+}

--- a/packages/mvvm-core/src/viewmodels/CachedRestfulApiViewModel.test.ts
+++ b/packages/mvvm-core/src/viewmodels/CachedRestfulApiViewModel.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { z } from 'zod';
+import { BehaviorSubject } from 'rxjs';
+import { CachedRestfulApiModel } from '../models/CachedRestfulApiModel';
+import { CachedRestfulApiViewModel } from './CachedRestfulApiViewModel';
+
+// Define a simple schema and type for testing
+const TestItemSchema = z.object({
+  id: z.string(),
+  value: z.string(),
+});
+type TestItem = z.infer<typeof TestItemSchema>;
+
+const TestItemArraySchema = z.array(TestItemSchema);
+type TestItemArray = z.infer<typeof TestItemArraySchema>;
+
+// Mock CachedRestfulApiModel
+vi.mock('../models/CachedRestfulApiModel', () => {
+  return {
+    CachedRestfulApiModel: vi.fn().mockImplementation(() => ({
+      data$: new BehaviorSubject<any>(null),
+      isLoading$: new BehaviorSubject<boolean>(false),
+      error$: new BehaviorSubject<any>(null),
+      query: vi.fn(() => Promise.resolve()),
+      create: vi.fn(() => Promise.resolve()),
+      update: vi.fn(() => Promise.resolve()),
+      delete: vi.fn(() => Promise.resolve()),
+      dispose: vi.fn(),
+    })),
+    // Ensure ExtractItemType is available if needed by the ViewModel file itself,
+    // though for testing it's usually not directly an issue.
+    ExtractItemType: (type: any) => type, // Simplistic mock if needed
+  };
+});
+
+describe('CachedRestfulApiViewModel', () => {
+  let mockModelInstance: CachedRestfulApiModel<TestItemArray, typeof TestItemArraySchema>;
+  let viewModel: CachedRestfulApiViewModel<TestItemArray, typeof TestItemArraySchema>;
+
+  beforeEach(() => {
+    // Create a new mock model instance for each test
+    mockModelInstance = new CachedRestfulApiModel<TestItemArray, typeof TestItemArraySchema>({
+      // Dummy constructor args for the mock, actual values don't matter due to mocking
+      queryCore: {} as any,
+      endpointKey: 'test',
+      schema: TestItemArraySchema,
+    });
+    viewModel = new CachedRestfulApiViewModel(mockModelInstance);
+  });
+
+  afterEach(() => {
+    viewModel.dispose(); // Ensure dispose is called, which should call model's dispose
+    vi.clearAllMocks(); // Clear all mocks
+  });
+
+  it('should be instantiated with a CachedRestfulApiModel', () => {
+    expect(viewModel).toBeInstanceOf(CachedRestfulApiViewModel);
+    expect(viewModel.data$).toBe(mockModelInstance.data$);
+    expect(viewModel.isLoading$).toBe(mockModelInstance.isLoading$);
+    expect(viewModel.error$).toBe(mockModelInstance.error$);
+  });
+
+  it('queryCommand should call model.query', async () => {
+    await viewModel.queryCommand.execute();
+    expect(mockModelInstance.query).toHaveBeenCalledWith(false); // Default forceRefetch
+  });
+
+  it('queryCommand should call model.query with forceRefetch true', async () => {
+    await viewModel.queryCommand.execute(true);
+    expect(mockModelInstance.query).toHaveBeenCalledWith(true);
+  });
+
+  it('createCommand should call model.create', async () => {
+    const payload: Partial<TestItem> = { value: 'new item' };
+    await viewModel.createCommand.execute(payload);
+    expect(mockModelInstance.create).toHaveBeenCalledWith(payload);
+  });
+
+  it('updateCommand should call model.update', async () => {
+    const id = 'item1';
+    const payload: Partial<TestItem> = { value: 'updated item' };
+    await viewModel.updateCommand.execute({ id, payload });
+    expect(mockModelInstance.update).toHaveBeenCalledWith(id, payload);
+  });
+
+  it('deleteCommand should call model.delete', async () => {
+    const id = 'item1';
+    await viewModel.deleteCommand.execute(id);
+    expect(mockModelInstance.delete).toHaveBeenCalledWith(id);
+  });
+
+  it('dispose should call model.dispose and command disposals', () => {
+    const queryDisposeSpy = vi.spyOn(viewModel.queryCommand, 'dispose');
+    const createDisposeSpy = vi.spyOn(viewModel.createCommand, 'dispose');
+    const updateDisposeSpy = vi.spyOn(viewModel.updateCommand, 'dispose');
+    const deleteDisposeSpy = vi.spyOn(viewModel.deleteCommand, 'dispose');
+
+    viewModel.dispose();
+
+    expect(mockModelInstance.dispose).toHaveBeenCalled();
+    expect(queryDisposeSpy).toHaveBeenCalled();
+    expect(createDisposeSpy).toHaveBeenCalled();
+    expect(updateDisposeSpy).toHaveBeenCalled();
+    expect(deleteDisposeSpy).toHaveBeenCalled();
+  });
+
+  describe('selectedItem$', () => {
+    const item1: TestItem = { id: '1', value: 'Item 1' };
+    const item2: TestItem = { id: '2', value: 'Item 2' };
+    const initialData: TestItemArray = [item1, item2];
+
+    beforeEach(() => {
+        // Resetup with a model that can emit data
+        (mockModelInstance.data$ as BehaviorSubject<TestItemArray | null>).next(initialData);
+    });
+
+    it('should initially be null', (done) => {
+      viewModel.selectedItem$.subscribe((selected) => {
+        expect(selected).toBeNull();
+        done();
+      });
+    });
+
+    it('should update when selectItem is called and item exists in data$', (done) => {
+      let emissionCount = 0;
+      viewModel.selectedItem$.subscribe((selected) => {
+        emissionCount++;
+        if (emissionCount === 1) {
+          expect(selected).toBeNull(); // Initial emission
+        } else if (emissionCount === 2) {
+          expect(selected).toEqual(item1); // After selection
+          done();
+        }
+      });
+      viewModel.selectItem('1');
+    });
+
+    it('should be null if selectedId does not match any item in data$', (done) => {
+      let emissionCount = 0;
+      viewModel.selectedItem$.subscribe((selected) => {
+        emissionCount++;
+        if (emissionCount === 1) {
+          expect(selected).toBeNull();
+        } else if (emissionCount === 2) {
+          expect(selected).toBeNull(); // Item '3' does not exist
+          done();
+        }
+      });
+      viewModel.selectItem('3');
+    });
+
+    it('should update if data$ changes and selectedId matches a new item', (done) => {
+      viewModel.selectItem('3'); // Select an ID that's not initially present
+
+      const newItem: TestItem = { id: '3', value: 'Item 3' };
+      const newData: TestItemArray = [...initialData, newItem];
+
+      let emissionCount = 0;
+      viewModel.selectedItem$.subscribe((selected) => {
+        emissionCount++;
+        if (emissionCount === 1) { // Initial from combineLatest with current _selectedItemId$
+          expect(selected).toBeNull(); // '3' not in initialData
+        } else if (emissionCount === 2) { // After data$ emits newData
+          expect(selected).toEqual(newItem);
+          done();
+        }
+      });
+      // Simulate data$ update from the model
+      (mockModelInstance.data$ as BehaviorSubject<TestItemArray | null>).next(newData);
+    });
+
+    it('should become null if selected item is removed from data$', (done) => {
+      viewModel.selectItem('1'); // Select item1
+
+      let emissionCount = 0;
+      viewModel.selectedItem$.subscribe((selected) => {
+        emissionCount++;
+        if (emissionCount === 1) {
+          expect(selected).toEqual(item1); // Initially selected
+        } else if (emissionCount === 2) {
+          expect(selected).toBeNull(); // After item1 is removed
+          done();
+        }
+      });
+
+      // Simulate item1 being removed from data$
+      (mockModelInstance.data$ as BehaviorSubject<TestItemArray | null>).next([item2]);
+    });
+
+     it('should be null if data$ is null', (done) => {
+      viewModel.selectItem('1'); // Try to select something
+
+      let emissionCount = 0;
+      viewModel.selectedItem$.subscribe((selected) => {
+        emissionCount++;
+        if (emissionCount === 1) { // initialData was set
+          expect(selected).toEqual(item1);
+        } else if (emissionCount === 2) { // data becomes null
+          expect(selected).toBeNull();
+          done();
+        }
+      });
+      (mockModelInstance.data$ as BehaviorSubject<TestItemArray | null>).next(null);
+    });
+  });
+});

--- a/packages/mvvm-core/src/viewmodels/CachedRestfulApiViewModel.ts
+++ b/packages/mvvm-core/src/viewmodels/CachedRestfulApiViewModel.ts
@@ -1,0 +1,120 @@
+import { BehaviorSubject, Observable, combineLatest } from 'rxjs';
+import { map, startWith } from 'rxjs/operators';
+import { CachedRestfulApiModel, ExtractItemType } from '../models/CachedRestfulApiModel';
+import { Command } from '../commands/Command';
+import { ZodSchema } from 'zod';
+
+// Helper type for items with an ID, assuming a common structure
+type ItemWithId = { id: string; [key: string]: any };
+
+/**
+ * @class CachedRestfulApiViewModel
+ * A generic ViewModel to facilitate operations and state management for a
+ * CachedRestfulApiModel. It exposes data, loading states, and errors as observables,
+ * and operations as commands, leveraging QueryCore through the model.
+ * @template TData The type of data managed by the underlying CachedRestfulApiModel.
+ * @template TSchema The Zod schema type for validating the data.
+ */
+export class CachedRestfulApiViewModel<TData, TSchema extends ZodSchema<TData>> {
+  protected model: CachedRestfulApiModel<TData, TSchema>;
+
+  /**
+   * Exposes the current data from the CachedRestfulApiModel.
+   */
+  public readonly data$: Observable<TData | null>;
+
+  /**
+   * Exposes the loading state from the CachedRestfulApiModel.
+   */
+  public readonly isLoading$: Observable<boolean>;
+
+  /**
+   * Exposes any error from the CachedRestfulApiModel.
+   */
+  public readonly error$: Observable<any>;
+
+  // Commands
+  public readonly queryCommand: Command<boolean | void, void>; // Parameter: forceRefetch (optional)
+  public readonly createCommand: Command<Partial<ExtractItemType<TData>> | Partial<ExtractItemType<TData>>[], void>;
+  public readonly updateCommand: Command<{ id: string; payload: Partial<ExtractItemType<TData>> }, void>;
+  public readonly deleteCommand: Command<string, void>;
+
+  // Optional: For managing selection if TData is an array of items
+  public readonly selectedItem$: Observable<ExtractItemType<TData> | null>;
+  protected readonly _selectedItemId$ = new BehaviorSubject<string | null>(null);
+
+  /**
+   * @param model An instance of CachedRestfulApiModel that this ViewModel will manage.
+   */
+  constructor(model: CachedRestfulApiModel<TData, TSchema>) {
+    if (!(model instanceof CachedRestfulApiModel)) {
+      throw new Error('CachedRestfulApiViewModel requires an instance of CachedRestfulApiModel.');
+    }
+    this.model = model;
+
+    this.data$ = this.model.data$;
+    this.isLoading$ = this.model.isLoading$;
+    this.error$ = this.model.error$;
+
+    // Initialize Commands
+    this.queryCommand = new Command(async (forceRefetch?: boolean) => {
+      await this.model.query(forceRefetch || false);
+    });
+
+    this.createCommand = new Command(
+      async (payload: Partial<ExtractItemType<TData>> | Partial<ExtractItemType<TData>>[]) => {
+        await this.model.create(payload);
+      },
+    );
+
+    this.updateCommand = new Command(
+      async ({ id, payload }: { id: string; payload: Partial<ExtractItemType<TData>> }) => {
+        await this.model.update(id, payload);
+      },
+    );
+
+    this.deleteCommand = new Command(async (id: string) => {
+      await this.model.delete(id);
+    });
+
+    // Selected item logic (meaningful if TData is an array)
+    this.selectedItem$ = combineLatest([this.model.data$, this._selectedItemId$]).pipe(
+      map(([data, selectedId]) => {
+        if (Array.isArray(data) && selectedId) {
+          const itemWithId = data.find((item: unknown): item is ItemWithId => {
+            return (
+              typeof item === 'object' &&
+              item !== null &&
+              'id' in item &&
+              typeof (item as any).id === 'string' &&
+              (item as any).id === selectedId
+            );
+          });
+          return (itemWithId as ExtractItemType<TData>) || null;
+        }
+        return null;
+      }),
+      startWith(null),
+    );
+  }
+
+  /**
+   * Selects an item by its ID.
+   * @param id The ID of the item to select. Pass null to clear selection.
+   */
+  public selectItem(id: string | null): void {
+    this._selectedItemId$.next(id);
+  }
+
+  /**
+   * Disposes of resources held by the ViewModel.
+   */
+  public dispose(): void {
+    this.model.dispose();
+    this.queryCommand.dispose();
+    this.createCommand.dispose();
+    this.updateCommand.dispose();
+    this.deleteCommand.dispose();
+    this._selectedItemId$.complete();
+  }
+}


### PR DESCRIPTION
- Introduces CachedRestfulApiModel, which leverages QueryCore for data fetching and caching.
- Adds CachedRestfulApiViewModel to manage CachedRestfulApiModel.
- Includes CUD operations in CachedRestfulApiModel with cache invalidation.
- Provides comprehensive unit tests for both new classes with mocked dependencies.
- Updates mvvm-core index.ts to export new classes and types.
- Updates README.md with documentation and usage examples for the new cached API classes.