### PR TITLE
Review and align CachedRestfulApi classes with QueryCore

### DIFF
--- a/packages/mvvm-core/UsingQueryCoreWithMVVM.md
+++ b/packages/mvvm-core/UsingQueryCoreWithMVVM.md
@@ -1,0 +1,15 @@
+# Using QueryCore with MVVM-Core
+
+This document outlines how to integrate `@web-loom/query-core` for advanced data caching and synchronization with the models and ViewModels provided by `mvvm-core`.
+
+## CachedRestfulApiModel and CachedRestfulApiViewModel
+
+The primary components for this integration are `CachedRestfulApiModel` and `CachedRestfulApiViewModel`. They allow `QueryCore` to manage the data lifecycle (fetching, caching, background updates) while `mvvm-core` structures the presentation logic.
+
+For a detailed explanation and example usage, please refer to [Section 3.5 in the main README.md](./README.md#35-using-cachedrestfulapimodel-and-cachedrestfulapiviewmodel-with-querycore).
+
+## Benefits
+
+-   **Shared Cache:** Data fetched by `QueryCore` can be shared across multiple ViewModels or application parts.
+-   **Automatic Refetching:** Leverage `QueryCore`'s built-in mechanisms for refetching on window focus, reconnect, or stale data intervals.
+-   **Decoupling:** Separates data fetching/caching concerns from UI/ViewModel logic.

--- a/packages/mvvm-core/src/viewmodels/CachedRestfulApiViewModel.ts
+++ b/packages/mvvm-core/src/viewmodels/CachedRestfulApiViewModel.ts
@@ -18,10 +18,10 @@ type ItemWithId = { id: string; [key: string]: any };
  * A generic ViewModel to facilitate interactions with a CachedRestfulApiModel.
  * It exposes data, loading states, errors, and commands to refresh or invalidate the cache.
  * @template TData The type of data managed by the underlying CachedRestfulApiModel (e.g., User, User[]).
- * @template TSchema The Zod schema type for validating the data (used by the model).
+ * @template TModelSchema The Zod schema type for validating TData, matching the schema used by the model.
  */
-export class CachedRestfulApiViewModel<TData, TSchema extends ZodSchema<ExtractItemType<TData>>> {
-  protected model: ICachedRestfulApiModel<TData, TSchema>;
+export class CachedRestfulApiViewModel<TData, TModelSchema extends ZodSchema<TData>> {
+  protected model: ICachedRestfulApiModel<TData, TModelSchema>;
 
   /**
    * Exposes the current data from the CachedRestfulApiModel.
@@ -59,7 +59,7 @@ export class CachedRestfulApiViewModel<TData, TSchema extends ZodSchema<ExtractI
   /**
    * @param model An instance of CachedRestfulApiModel that this ViewModel will manage.
    */
-  constructor(model: ICachedRestfulApiModel<TData, TSchema>) {
+  constructor(model: ICachedRestfulApiModel<TData, TModelSchema>) {
     // It's good practice to check if the provided model is of the expected type,
     // but ICachedRestfulApiModel is an interface. instanceof won't work directly with interfaces.
     // We rely on TypeScript's structural typing or add a runtime check if necessary (e.g., check for specific methods).


### PR DESCRIPTION
- Reviewed CachedRestfulApiModel and CachedRestfulApiViewModel for compatibility with QueryCore and MVVM patterns.
- Made minor code adjustments for schema handling and endpoint definition logic in CachedRestfulApiModel.
- Corrected generic type definitions in CachedRestfulApiViewModel for better type safety with the model's schema.
- Updated tests for both classes to reflect these changes, primarily correcting schema usage in test setups and addressing issues in a model test.
- Added documentation to README.md for CachedRestfulApiModel and CachedRestfulApiViewModel, explaining their usage with QueryCore.