### PR TITLE
Refactor: Rename CachedRestfulApi to QueryState

### DIFF
--- a/packages/mvvm-core/README.md
+++ b/packages/mvvm-core/README.md
@@ -195,11 +195,11 @@ export class AuthViewModel {
 }
 ```
 
-### 3.5. Using CachedRestfulApiModel and CachedRestfulApiViewModel (with QueryCore)
+### 3.5. Using QueryStateModel and QueryStateModelView (with QueryCore)
 
-For applications requiring more sophisticated data caching, automatic refetching, and shared data states across different parts of the application, `CachedRestfulApiModel` and `CachedRestfulApiViewModel` provide an integration with the `@web-loom/query-core` library. This approach is suitable when you want QueryCore to manage the lifecycle of your data (fetching, caching, background updates) while still leveraging the MVVM pattern for your UI logic.
+For applications requiring more sophisticated data caching, automatic refetching, and shared data states across different parts of the application, `QueryStateModel` and `QueryStateModelView` provide an integration with the `@web-loom/query-core` library. This approach is suitable when you want QueryCore to manage the lifecycle of your data (fetching, caching, background updates) while still leveraging the MVVM pattern for your UI logic.
 
-**a. `CachedRestfulApiModel<TData, TSchema extends ZodSchema<TData>>`**
+**a. `QueryStateModel<TData, TSchema extends ZodSchema<TData>>`**
 
 This model acts as a bridge between your ViewModel and a `QueryCore` instance. Instead of directly fetching data, it subscribes to a specific endpoint managed by `QueryCore`.
 
@@ -215,12 +215,12 @@ This model acts as a bridge between your ViewModel and a `QueryCore` instance. I
     -   `invalidate(): Promise<void>`: Invalidates the cached data for this endpoint in `QueryCore`.
 -   **Reactive Properties (from BaseModel)**: `data$`, `isLoading$`, `error$`, `isError$`. These are updated based on the state from `QueryCore`.
 
-**b. `CachedRestfulApiViewModel<TData, TModelSchema extends ZodSchema<TData>>`**
+**b. `QueryStateModelView<TData, TModelSchema extends ZodSchema<TData>>`**
 
-This ViewModel wraps a `CachedRestfulApiModel` and exposes its data and cache-related operations as commands.
+This ViewModel wraps a `QueryStateModel` and exposes its data and cache-related operations as commands.
 
 -   **Constructor**:
-    -   `model: ICachedRestfulApiModel<TData, TModelSchema>`: An instance of `CachedRestfulApiModel`.
+    -   `model: IQueryStateModel<TData, TModelSchema>`: An instance of `QueryStateModel`.
 -   **Key Properties**:
     -   `data$`, `isLoading$`, `error$`: Observables directly from the underlying model.
     -   `refetchCommand: Command<boolean | void, void>`: Command to trigger `model.refetch()`. Can take an optional `force` parameter.
@@ -249,12 +249,12 @@ queryCore.defineEndpoint<User[]>('allUsers', fetchAllUsers);
 
 
 // user.model.ts (assuming User and UserSchema are defined as before)
-import { CachedRestfulApiModel } from 'mvvm-core/CachedRestfulApiModel'; // Adjust path
+import { QueryStateModel } from 'mvvm-core/QueryStateModel'; // Adjust path
 import { queryCore } from './queryCoreInstance';
 import { User, UserSchema } from './user.model.types'; // Assuming types are separate
 import { z } from 'zod';
 
-export class AllUsersCachedModel extends CachedRestfulApiModel<User[], z.ZodArray<typeof UserSchema>> {
+export class AllUsersQueryStateModel extends QueryStateModel<User[], z.ZodArray<typeof UserSchema>> {
   constructor() {
     super({
       queryCore: queryCore,
@@ -266,14 +266,14 @@ export class AllUsersCachedModel extends CachedRestfulApiModel<User[], z.ZodArra
 }
 
 // user.viewmodel.ts
-import { CachedRestfulApiViewModel } from 'mvvm-core/CachedRestfulApiViewModel'; // Adjust path
-import { AllUsersCachedModel } from './user.model';
+import { QueryStateModelView } from 'mvvm-core/QueryStateModelView'; // Adjust path
+import { AllUsersQueryStateModel } from './user.model';
 import { User, UserSchema } from './user.model.types';
 import { z } from 'zod';
 
-export class AllUsersViewModel extends CachedRestfulApiViewModel<User[], z.ZodArray<typeof UserSchema>> {
+export class AllUsersViewModel extends QueryStateModelView<User[], z.ZodArray<typeof UserSchema>> {
   constructor() {
-    super(new AllUsersCachedModel());
+    super(new AllUsersQueryStateModel());
   }
 
   // Example: Get a specific user from the cached list

--- a/packages/mvvm-core/src/models/QueryStateModel.test.ts
+++ b/packages/mvvm-core/src/models/QueryStateModel.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { z } from 'zod';
 import { BehaviorSubject, firstValueFrom } from 'rxjs';
-import { CachedRestfulApiModel, TCachedRestfulApiModelConstructor } from './CachedRestfulApiModel';
+import { QueryStateModel, TQueryStateModelConstructor } from './QueryStateModel';
 
 // Define a simple Zod schema for testing
 const ItemSchema = z.object({
@@ -96,7 +96,7 @@ const createMockQueryCoreInstance = () => {
 // Create a mock QueryCore constructor
 const MockQueryCore = vi.fn(createMockQueryCoreInstance);
 
-describe('CachedRestfulApiModel', () => {
+describe('QueryStateModel', () => {
   let mockQueryCoreInstance: any; // Use any type to avoid interface conflicts
   // Helper to access the mock simulation methods, which are now on the instance returned by the mock constructor
   let mockQueryCoreSimulator: {
@@ -121,9 +121,9 @@ describe('CachedRestfulApiModel', () => {
   });
 
   const createModel = (
-    constructorInput?: Partial<TCachedRestfulApiModelConstructor<ItemArray, typeof itemArrayTestSchema>>,
+    constructorInput?: Partial<TQueryStateModelConstructor<ItemArray, typeof itemArrayTestSchema>>,
   ) => {
-    return new CachedRestfulApiModel<ItemArray, typeof itemArrayTestSchema>({
+    return new QueryStateModel<ItemArray, typeof itemArrayTestSchema>({
       queryCore: mockQueryCoreInstance,
       endpointKey,
       schema: itemArrayTestSchema, // Correct schema for ItemArray
@@ -145,7 +145,7 @@ describe('CachedRestfulApiModel', () => {
     // Mock QueryCore subscribe callback is called synchronously with { data: undefined, ... }.
     // BaseModel initializes _data$ with (undefined ?? null) = null.
     // Mock QueryCore subscribe callback is called synchronously with { data: undefined, ... }.
-    // CachedRestfulApiModel.setData(undefined) is called.
+    // QueryStateModel.setData(undefined) is called.
     // So _data$ in BaseModel is now BehaviorSubject(undefined).
     // firstValueFrom will get the current value, which should be undefined.
     expect(await firstValueFrom(model.data$)).toBeNull();
@@ -276,7 +276,7 @@ describe('CachedRestfulApiModel', () => {
 
     // BaseModel constructor sets _data$ to initialItems.
     // QueryCore mock's subscribe callback is called synchronously with { data: undefined, ... }.
-    // CachedRestfulApiModel.setData(undefined) is called.
+    // QueryStateModel.setData(undefined) is called.
     // So _data$ in BaseModel is now BehaviorSubject(undefined).
     // firstValueFrom will get the current value, which should be undefined.
     expect(await firstValueFrom(model.data$)).toBeNull();

--- a/packages/mvvm-core/src/models/QueryStateModel.ts
+++ b/packages/mvvm-core/src/models/QueryStateModel.ts
@@ -5,8 +5,8 @@ import { EndpointState, QueryCore } from '@web-loom/query-core'; // Assuming Que
 // Helper type to extract the underlying type if T is an array, otherwise returns T
 export type ExtractItemType<T> = T extends (infer U)[] ? U : T;
 
-export interface ICachedRestfulApiModel<TData, TSchema extends ZodSchema<TData>> extends IBaseModel<TData, TSchema> {
-  // Define specific methods for CachedRestfulApiModel if they differ from BaseModel
+export interface IQueryStateModel<TData, TSchema extends ZodSchema<TData>> extends IBaseModel<TData, TSchema> {
+  // Define specific methods for QueryStateModel if they differ from BaseModel
   // or if new public methods are introduced.
   // For now, it will rely on QueryCore for most operations.
   // We might need a manual refetch trigger.
@@ -14,7 +14,7 @@ export interface ICachedRestfulApiModel<TData, TSchema extends ZodSchema<TData>>
   invalidate(): Promise<void>;
 }
 
-export type TCachedRestfulApiModelConstructor<TData, TSchema extends ZodSchema<TData>> = {
+export type TQueryStateModelConstructor<TData, TSchema extends ZodSchema<TData>> = {
   queryCore: QueryCore;
   endpointKey: string;
   schema: TSchema; // Zod schema for validating TData. If TData is an array, this schema should validate the array (e.g., z.array(itemSchema)).
@@ -26,16 +26,16 @@ export type TCachedRestfulApiModelConstructor<TData, TSchema extends ZodSchema<T
 };
 
 /**
- * @class CachedRestfulApiModel
+ * @class QueryStateModel
  * Extends BaseModel to provide capabilities for interacting with data sources
  * managed by QueryCore. It handles data, loading states, and errors based on
  * QueryCore's state management and caching.
  * @template TData The type of data managed by the model (e.g., User, User[]).
  * @template TSchema The Zod schema type for validating the data.
  */
-export class CachedRestfulApiModel<TData, TSchema extends ZodSchema<TData>>
+export class QueryStateModel<TData, TSchema extends ZodSchema<TData>>
   extends BaseModel<TData, TSchema>
-  implements ICachedRestfulApiModel<TData, TSchema>
+  implements IQueryStateModel<TData, TSchema>
 {
   private queryCore: QueryCore;
   private endpointKey: string;
@@ -49,7 +49,7 @@ export class CachedRestfulApiModel<TData, TSchema extends ZodSchema<TData>>
    * @param fetcherFn Optional fetcher function if the endpoint needs to be defined.
    * @param refetchAfter Optional refetch interval for this endpoint.
    */
-  constructor(input: TCachedRestfulApiModelConstructor<TData, TSchema>) {
+  constructor(input: TQueryStateModelConstructor<TData, TSchema>) {
     super({ initialData: input.initialData ?? null, schema: input.schema });
 
     this.queryCore = input.queryCore;
@@ -153,7 +153,7 @@ export class CachedRestfulApiModel<TData, TSchema extends ZodSchema<TData>>
    * QueryCore itself is read-focused. Mutations are typically handled outside QueryCore's direct responsibility,
    * with QueryCore then being told to update its cache (e.g., via refetch or invalidate).
    *
-   * For this generic CachedRestfulApiModel, we cannot assume how mutations are performed.
+   * For this generic QueryStateModel, we cannot assume how mutations are performed.
    * The consumer of this model would typically:
    * - Call their own API service for CUD operations.
    * - Then call `this.model.refetch()` or `this.model.invalidate()` on this model instance.

--- a/packages/mvvm-core/src/viewmodels/QueryStateModelView.test.ts
+++ b/packages/mvvm-core/src/viewmodels/QueryStateModelView.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { z } from 'zod';
 import { BehaviorSubject, firstValueFrom } from 'rxjs';
 import { skip, filter, take } from 'rxjs/operators';
-import { CachedRestfulApiModel, ICachedRestfulApiModel, ExtractItemType } from '../models/CachedRestfulApiModel';
-import { CachedRestfulApiViewModel } from './CachedRestfulApiViewModel';
+import { QueryStateModel, IQueryStateModel, ExtractItemType } from '../models/QueryStateModel';
+import { QueryStateModelView } from './QueryStateModelView';
 import { Command } from '../commands/Command'; // For spy checks if needed
 
 // Define a simple Zod schema for testing
@@ -15,8 +15,8 @@ type Item = z.infer<typeof ItemSchema>;
 const ItemArraySchema = z.array(ItemSchema);
 type ItemArray = z.infer<typeof ItemArraySchema>;
 
-// Mock CachedRestfulApiModel
-class MockCachedRestfulApiModel<TData, TModelSchema extends ZodSchema<TData>> implements ICachedRestfulApiModel<TData, TModelSchema> {
+// Mock QueryStateModel
+class MockQueryStateModel<TData, TModelSchema extends ZodSchema<TData>> implements IQueryStateModel<TData, TModelSchema> {
   public _data$ = new BehaviorSubject<TData | null>(null);
   public _isLoading$ = new BehaviorSubject<boolean>(false);
   public _error$ = new BehaviorSubject<any>(null);
@@ -72,18 +72,18 @@ class MockCachedRestfulApiModel<TData, TModelSchema extends ZodSchema<TData>> im
   });
 }
 
-describe('CachedRestfulApiViewModel', () => {
+describe('QueryStateModelView', () => {
   // Typedef for the schema instances
   type ItemArraySchemaType = typeof ItemArraySchema;
   type ItemSchemaType = typeof ItemSchema;
 
-  let mockModel: MockCachedRestfulApiModel<ItemArray | null, ItemArraySchemaType>;
-  let viewModel: CachedRestfulApiViewModel<ItemArray | null, ItemArraySchemaType>;
+  let mockModel: MockQueryStateModel<ItemArray | null, ItemArraySchemaType>;
+  let viewModel: QueryStateModelView<ItemArray | null, ItemArraySchemaType>;
 
   beforeEach(() => {
     // Default to ItemArray model for most tests
-    mockModel = new MockCachedRestfulApiModel<ItemArray | null, ItemArraySchemaType>([], ItemArraySchema);
-    viewModel = new CachedRestfulApiViewModel<ItemArray | null, ItemArraySchemaType>(mockModel);
+    mockModel = new MockQueryStateModel<ItemArray | null, ItemArraySchemaType>([], ItemArraySchema);
+    viewModel = new QueryStateModelView<ItemArray | null, ItemArraySchemaType>(mockModel);
   });
 
   afterEach(() => {
@@ -92,8 +92,8 @@ describe('CachedRestfulApiViewModel', () => {
   });
 
   it('should throw an error if model is invalid', () => {
-    expect(() => new CachedRestfulApiViewModel(null as any)).toThrow('CachedRestfulApiViewModel requires a valid model instance that implements ICachedRestfulApiModel.');
-    expect(() => new CachedRestfulApiViewModel({} as any)).toThrow('CachedRestfulApiViewModel requires a valid model instance that implements ICachedRestfulApiModel.');
+    expect(() => new QueryStateModelView(null as any)).toThrow('QueryStateModelView requires a valid model instance that implements IQueryStateModel.');
+    expect(() => new QueryStateModelView({} as any)).toThrow('QueryStateModelView requires a valid model instance that implements IQueryStateModel.');
   });
 
   it('should expose data$, isLoading$, and error$ from the model', async () => {
@@ -183,8 +183,8 @@ describe('CachedRestfulApiViewModel', () => {
 
     beforeEach(() => {
       // Ensure the model is set up for ItemArray for these tests
-      mockModel = new MockCachedRestfulApiModel<ItemArray | null>(items);
-      viewModel = new CachedRestfulApiViewModel(mockModel);
+      mockModel = new MockQueryStateModel<ItemArray | null>(items, ItemArraySchema);
+      viewModel = new QueryStateModelView(mockModel);
     });
 
     it('should emit null initially for selectedItem$', async () => {
@@ -215,13 +215,13 @@ describe('CachedRestfulApiViewModel', () => {
   });
 
   describe('ViewModel with TData = Item (single item model)', () => {
-    let singleItemModel: MockCachedRestfulApiModel<Item | null, ItemSchemaType>;
-    let singleItemViewModel: CachedRestfulApiViewModel<Item | null, ItemSchemaType>;
+    let singleItemModel: MockQueryStateModel<Item | null, ItemSchemaType>;
+    let singleItemViewModel: QueryStateModelView<Item | null, ItemSchemaType>;
     const singleItem: Item = { id: 'single', name: 'Single Item Only' };
 
     beforeEach(() => {
-      singleItemModel = new MockCachedRestfulApiModel<Item | null, ItemSchemaType>(singleItem, ItemSchema);
-      singleItemViewModel = new CachedRestfulApiViewModel<Item | null, ItemSchemaType>(singleItemModel);
+      singleItemModel = new MockQueryStateModel<Item | null, ItemSchemaType>(singleItem, ItemSchema);
+      singleItemViewModel = new QueryStateModelView<Item | null, ItemSchemaType>(singleItemModel);
     });
 
     afterEach(() => {

--- a/packages/mvvm-core/src/viewmodels/QueryStateModelView.ts
+++ b/packages/mvvm-core/src/viewmodels/QueryStateModelView.ts
@@ -1,5 +1,5 @@
 import { Observable } from 'rxjs';
-import { CachedRestfulApiModel, ICachedRestfulApiModel, ExtractItemType } from '../models/CachedRestfulApiModel';
+import { QueryStateModel, IQueryStateModel, ExtractItemType } from '../models/QueryStateModel';
 import { Command } from '../commands/Command';
 import { ZodSchema } from 'zod';
 
@@ -14,27 +14,27 @@ type ItemWithId = { id: string; [key: string]: any };
 
 
 /**
- * @class CachedRestfulApiViewModel
- * A generic ViewModel to facilitate interactions with a CachedRestfulApiModel.
+ * @class QueryStateModelView
+ * A generic ViewModel to facilitate interactions with a QueryStateModel.
  * It exposes data, loading states, errors, and commands to refresh or invalidate the cache.
- * @template TData The type of data managed by the underlying CachedRestfulApiModel (e.g., User, User[]).
+ * @template TData The type of data managed by the underlying QueryStateModel (e.g., User, User[]).
  * @template TModelSchema The Zod schema type for validating TData, matching the schema used by the model.
  */
-export class CachedRestfulApiViewModel<TData, TModelSchema extends ZodSchema<TData>> {
-  protected model: ICachedRestfulApiModel<TData, TModelSchema>;
+export class QueryStateModelView<TData, TModelSchema extends ZodSchema<TData>> {
+  protected model: IQueryStateModel<TData, TModelSchema>;
 
   /**
-   * Exposes the current data from the CachedRestfulApiModel.
+   * Exposes the current data from the QueryStateModel.
    */
   public readonly data$: Observable<TData | null>;
 
   /**
-   * Exposes the loading state of the CachedRestfulApiModel.
+   * Exposes the loading state of the QueryStateModel.
    */
   public readonly isLoading$: Observable<boolean>;
 
   /**
-   * Exposes any error encountered by the CachedRestfulApiModel.
+   * Exposes any error encountered by the QueryStateModel.
    */
   public readonly error$: Observable<any>;
 
@@ -57,14 +57,14 @@ export class CachedRestfulApiViewModel<TData, TModelSchema extends ZodSchema<TDa
 
 
   /**
-   * @param model An instance of CachedRestfulApiModel that this ViewModel will manage.
+   * @param model An instance of QueryStateModel that this ViewModel will manage.
    */
-  constructor(model: ICachedRestfulApiModel<TData, TModelSchema>) {
+  constructor(model: IQueryStateModel<TData, TModelSchema>) {
     // It's good practice to check if the provided model is of the expected type,
-    // but ICachedRestfulApiModel is an interface. instanceof won't work directly with interfaces.
+    // but IQueryStateModel is an interface. instanceof won't work directly with interfaces.
     // We rely on TypeScript's structural typing or add a runtime check if necessary (e.g., check for specific methods).
     if (!model || typeof model.refetch !== 'function' || typeof model.invalidate !== 'function') {
-        throw new Error('CachedRestfulApiViewModel requires a valid model instance that implements ICachedRestfulApiModel.');
+        throw new Error('QueryStateModelView requires a valid model instance that implements IQueryStateModel.');
     }
     this.model = model;
 


### PR DESCRIPTION
Renamed CachedRestfulApiModel to QueryStateModel and CachedRestfulApiViewModel to QueryStateModelView.

Updated all relevant import paths, class names, and documentation to reflect these changes.

Note: Automated tests could not be run in the execution environment prior to this commit.