### PR TITLE
fix: Address TS errors in @web-loom/mvvm-core and update dependent co…

### DIFF
--- a/apps/mvvm-angular/tsconfig.app.json
+++ b/apps/mvvm-angular/tsconfig.app.json
@@ -10,7 +10,8 @@
       "@repo/models": ["../../packages/models/src"],
       "@repo/models/*": ["../../packages/models/src/*"],
       "@repo/view-models": ["../../packages/view-models/src"],
-      "@repo/view-models/*": ["../../packages/view-models/src/*"]
+      "@repo/view-models/*": ["../../packages/view-models/src/*"],
+      "@web-loom/mvvm-core": ["../../node_modules/@web-loom/mvvm-core"]
     }
   },
   "references": [

--- a/packages/models/tsconfig.json
+++ b/packages/models/tsconfig.json
@@ -8,7 +8,11 @@
     "module": "ESNext", // or "ES2022"
     "target": "ES2022",
     "moduleResolution": "bundler",
-    "rootDir": "src"
+    "rootDir": "src",
+    "baseUrl": ".",
+    "paths": {
+      "@web-loom/mvvm-core": ["../../node_modules/@web-loom/mvvm-core"]
+    }
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]

--- a/packages/mvvm-core/src/examples/error-handling-demo.ts
+++ b/packages/mvvm-core/src/examples/error-handling-demo.ts
@@ -1,7 +1,7 @@
 import { SimpleDIContainer, ServiceRegistry } from '../core/di-container';
 import { GlobalErrorService, HandledError } from '../services/global-error-service';
 import { NotificationService } from '../services/notification-service'; // For showing errors as notifications
-import { Subscription, throwError, timer, of } from 'rxjs';
+import { Observable, Subscription, throwError, timer, of } from 'rxjs';
 import { catchError, map, switchMap } from 'rxjs/operators';
 
 // Augment ServiceRegistry for this example

--- a/packages/mvvm-core/src/examples/notification-demo.ts
+++ b/packages/mvvm-core/src/examples/notification-demo.ts
@@ -1,4 +1,4 @@
-import { SimpleDIContainer, ServiceRegistry } from '../core/di-container';
+import { SimpleDIContainer } from '../core/di-container';
 import { NotificationService, Notification } from '../services/notification-service';
 import { Subscription } from 'rxjs';
 
@@ -51,7 +51,7 @@ export async function runNotificationDemo() {
   notificationService.showWarning('Please check your input values.', 4000);
   await new Promise((resolve) => setTimeout(resolve, 500));
 
-  const errorId = notificationService.showError('An error occurred while processing your request!', 7000);
+  notificationService.showError('An error occurred while processing your request!', 7000); // Removed const errorId
   await new Promise((resolve) => setTimeout(resolve, 500));
 
   const persistentInfoId = notificationService.showPersistentInfo(

--- a/packages/mvvm-core/tsconfig.json
+++ b/packages/mvvm-core/tsconfig.json
@@ -14,6 +14,11 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "outDir": "dist",
+    "baseUrl": ".",
+    "paths": {
+      "rxjs": ["../../node_modules/rxjs"],
+      "rxjs/*": ["../../node_modules/rxjs/*"]
+    },
     /* Linting */
     "strict": true,
     "noUnusedLocals": true,


### PR DESCRIPTION
…nfigs

This commit attempts to resolve module resolution issues for `@web-loom/mvvm-core` across the monorepo.

Summary of changes and steps taken:

1.  **Initial Investigation & Hypothesis:**
    *   Identified that `@web-loom/mvvm-core` was not being resolved by `packages/models` and `apps/mvvm-angular`.
    *   Discovered that the `dist` folder for the local workspace package `packages/mvvm-core` was empty, despite its `package.json` pointing to `dist` for its main/module/types entries.
    *   Hypothesized that internal TypeScript errors within `packages/mvvm-core` were preventing its Vite build (specifically `vite-plugin-dts`) from generating the necessary `dist` files.

2.  **TypeScript Configuration Adjustments:**
    *   Added `baseUrl` and `paths` aliases for `@web-loom/mvvm-core` in:
        *   `apps/mvvm-angular/tsconfig.app.json` (pointing to `../../node_modules/@web-loom/mvvm-core`)
        *   `packages/models/tsconfig.json` (pointing to `../../node_modules/@web-loom/mvvm-core`)
    *   Added `baseUrl` and `paths` aliases for `rxjs` and `rxjs/*` in `packages/mvvm-core/tsconfig.json` to ensure RxJS types could be resolved during its own build.

3.  **Fixes within `packages/mvvm-core` Source Code:**
    *   `src/examples/error-handling-demo.ts`:
        *   Added `Observable` to the import from `rxjs`.
    *   `src/examples/di-setup.ts`:
        *   Added `from` to the import from `rxjs`.
        *   Modified the `userProfileFormFactory` submit handler to return `from(promise)` instead of a raw `Promise` to align with the expected `Observable` return type.
    *   `src/examples/notification-demo.ts`:
        *   Removed unused `ServiceRegistry` import.
        *   Removed unused `errorId` constant.

4.  **Current Status & Remaining Issues:**
    *   The primary goal was to get the `dist` folder of `packages/mvvm-core` populated. While its Vite build logs *claim* success in generating declaration files, the `ls` tool consistently reported the `dist` directory as empty. This discrepancy is the main blocker.
    *   There are still outstanding TypeScript errors in other example files within `packages/mvvm-core` (e.g., `product-list-example.ts`, `user-form-example.ts`) and in `src/services/global-error-service.ts`. These primarily involve missing `Observable` imports and incorrect usage of `.getValue()` on Observables.
    *   It's suspected these remaining internal errors are still preventing the `dist` files from being written correctly, despite the build logs.

I was in the process of systematically fixing these internal errors in `@web-loom/mvvm-core` with the expectation that a clean build of this package would then allow the rest of the monorepo to resolve it correctly. The interaction with the `ls` tool and build logs was confusing and made it difficult to confirm the state of the `dist` directory after each change.