### PR TITLE
feat: add @web-loom/mcp-server

### DIFF
--- a/.github/workflows/mcp-server-ci.yml
+++ b/.github/workflows/mcp-server-ci.yml
@@ -1,0 +1,41 @@
+# .github/workflows/mcp-server-ci.yml
+
+name: CI - @web-loom/mcp-server
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'packages/mcp-server/**'
+
+jobs:
+  build_and_test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'npm'
+
+      - name: Clean install
+        run: |
+          rm -rf node_modules
+          rm -f package-lock.json
+          npm i
+
+      - name: Type check @web-loom/mcp-server
+        run: npm run check-types --workspace=@web-loom/mcp-server
+
+      - name: Build @web-loom/mcp-server
+        run: npx turbo run build --filter=@web-loom/mcp-server
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: mcp-server-dist-build-artifacts
+          path: packages/mcp-server/dist/

--- a/.github/workflows/mcp-server-publish.yml
+++ b/.github/workflows/mcp-server-publish.yml
@@ -1,0 +1,65 @@
+# .github/workflows/mcp-server-publish.yml
+
+name: Publish - @web-loom/mcp-server
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'packages/mcp-server/**'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+
+      - name: Clean install
+        run: |
+          rm -rf node_modules
+          rm -f package-lock.json
+          npm i
+
+      - name: Build @web-loom/mcp-server
+        run: npx turbo run build --filter=@web-loom/mcp-server
+
+      - name: Publish @web-loom/mcp-server to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          cd packages/mcp-server
+
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          PACKAGE_NAME=$(node -p "require('./package.json').name")
+
+          echo "--- Package Information ---"
+          echo "Package Name: $PACKAGE_NAME"
+          echo "Package Version: $PACKAGE_VERSION"
+          echo "--------------------------"
+
+          set +e
+          npm view "$PACKAGE_NAME@$PACKAGE_VERSION" > /dev/null 2>&1
+          NPM_VIEW_EXIT_CODE=$?
+          set -e
+
+          if [ "$NPM_VIEW_EXIT_CODE" -eq 0 ]; then
+            echo "✅ Package version $PACKAGE_VERSION already exists on npm. Skipping publish for $PACKAGE_NAME."
+            exit 0
+          else
+            echo "🚀 Package version $PACKAGE_VERSION is new. Attempting to publish $PACKAGE_NAME."
+            npm publish --access public --verbose
+          fi
+
+          echo "--- Publish process completed for $PACKAGE_NAME ---"

--- a/package-lock.json
+++ b/package-lock.json
@@ -647,7 +647,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1227,7 +1226,6 @@
       "integrity": "sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1311,7 +1309,6 @@
     "apps/mvvm-react-native/node_modules/react": {
       "version": "19.0.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1348,7 +1345,6 @@
       "integrity": "sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1496,7 +1492,6 @@
       "version": "5.8.3",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -1611,7 +1606,6 @@
       "version": "19.1.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -1788,7 +1782,6 @@
       "integrity": "sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2855,7 +2848,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.8",
         "picocolors": "^1.1.1",
@@ -4148,7 +4140,6 @@
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-19.2.18.tgz",
       "integrity": "sha512-CrV02Omzw/QtfjlEVXVPJVXipdx83NuA+qSASZYrxrhKFusUZyK3P/Zznqg+wiAeNDbedQwMUVqoAARHf0xQrw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -4165,7 +4156,6 @@
       "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-19.2.18.tgz",
       "integrity": "sha512-3MscvODxRVxc3Cs0ZlHI5Pk5rEvE80otfvxZTMksOZuPlv1B+S8MjWfc3X3jk9SbyUEzODBEH55iCaBHD48V3g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -4179,7 +4169,6 @@
       "integrity": "sha512-N4TMtLfImJIoMaRL6mx7885UBeQidywptHH6ACZj71Ar6++DBc1mMlcwuvbeJCd3r3y8MQ5nLv5PZSN/tHr13w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "7.26.9",
         "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -4245,7 +4234,6 @@
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-19.2.18.tgz",
       "integrity": "sha512-+QRrf0Igt8ccUWXHA+7doK5W6ODyhHdqVyblSlcQ8OciwkzIIGGEYNZom5OZyWMh+oI54lcSeyV2O3xaDepSrQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -4280,7 +4268,6 @@
       "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-19.2.18.tgz",
       "integrity": "sha512-eahtsHPyXTYLARs9YOlXhnXGgzw0wcyOcDkBvNWK/3lA0NHIgIHmQgXAmBo+cJ+g9skiEQTD2OmSrrwbFKWJkw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -4383,7 +4370,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.7.tgz",
       "integrity": "sha512-BU2f9tlKQ5CAthiMIgpzAh4eDTLWo1mqi9jqE2OxMG0E/OM199VJt2q8BztTxpnSW0i1ymdwLXRJnYzvDM5r2w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -7008,7 +6994,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -7032,7 +7017,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7388,7 +7372,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7422,7 +7405,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7456,7 +7438,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8752,7 +8733,6 @@
       "resolved": "https://registry.npmjs.org/@expo/metro-runtime/-/metro-runtime-5.0.5.tgz",
       "integrity": "sha512-P8UFTi+YsmiD1BmdTdiIQITzDMcZgronsA3RTQ4QKJjHM3bas11oGzLQOnFaIZnlEV8Rrr3m1m+RHxvnpL+t/A==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react-native": "*"
       }
@@ -9216,7 +9196,6 @@
       "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-2.2.9.tgz",
       "integrity": "sha512-Mb+Un58gwBn0/yWZfyrCh0TJyurtT+dETj7YHleylHk5od3dv2XqETPGWMyQ5/7sYN7oWdyM1u9MvC0OC8UmzQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@floating-ui/react": "^0.26.16",
         "@react-aria/focus": "^3.20.2",
@@ -9230,6 +9209,18 @@
       "peerDependencies": {
         "react": "^18 || ^19 || ^19.0.0-rc",
         "react-dom": "^18 || ^19 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
       }
     },
     "node_modules/@humanfs/core": {
@@ -10045,7 +10036,6 @@
       "integrity": "sha512-G1ytyOoHh5BphmEBxSwALin3n1KGNYB6yImbICcRQdzXfOGbuJ9Jske/Of5Sebk339NSGGNfUshnzK8YWkTPsQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/checkbox": "^4.1.2",
         "@inquirer/confirm": "^5.1.6",
@@ -11165,7 +11155,6 @@
       "resolved": "https://registry.npmjs.org/@marko/compiler/-/compiler-5.39.47.tgz",
       "integrity": "sha512-IIxmObKbArwr49nyYZJnJetzGdxW2H3bjHEiJKB0OZkvloAW0l24MAmJYQvZSWH5kG1HHiwvMNH8m1d7u7RO0Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/core": "^7.28.0",
@@ -11201,7 +11190,6 @@
       "integrity": "sha512-BxsS7EnvsFeHK0O64y6wSKk+8Dfe3c1OKfMbmYd4+NpxgUw6dyY20iTttp+6RZWmoUYXF1VBBmRxiFLAOZpfyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@marko/run-explorer": "^2.0.1",
         "@marko/vite": "^5.4.2",
@@ -12091,6 +12079,385 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
@@ -13770,7 +14137,6 @@
       "version": "2.5.4",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.4.tgz",
       "integrity": "sha512-WYa2tUVV5HiArWPB3ydlOc4R2ivq0IDrlqhMi3l7mVsFEXNcTfxYFPIHXHXIh/ca/y/V5N4E1zecyxdIBjYnkQ==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -13810,7 +14176,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13831,7 +14196,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13852,7 +14216,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13873,7 +14236,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13894,7 +14256,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13915,7 +14276,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13936,7 +14296,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13957,7 +14316,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13978,7 +14336,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13999,7 +14356,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14020,7 +14376,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14041,7 +14396,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14062,7 +14416,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14538,7 +14891,6 @@
       "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-6.1.18.tgz",
       "integrity": "sha512-mIT9MiL/vMm4eirLcmw2h6h/Nm5FICtnYSdohq4vTLA2FF/6PNhByM7s8ffqoVfE5L0uAa6Xda1B7oddolUiGg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@react-navigation/core": "^6.4.17",
         "escape-string-regexp": "^4.0.0",
@@ -14686,7 +15038,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14700,7 +15051,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14714,7 +15064,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14728,7 +15077,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14742,7 +15090,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14756,7 +15103,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14770,7 +15116,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14784,7 +15129,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14798,7 +15142,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14812,7 +15155,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14826,7 +15168,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14840,7 +15181,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14882,7 +15222,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14896,7 +15235,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14910,7 +15248,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14924,7 +15261,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14938,7 +15274,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14952,7 +15287,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14966,7 +15300,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14980,7 +15313,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14994,7 +15326,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -15008,7 +15339,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -15022,7 +15352,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -15036,7 +15365,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -15050,7 +15378,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -15883,7 +16210,6 @@
       "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -16542,7 +16868,6 @@
       "integrity": "sha512-EwquDRUDVvWcZds3T2abmB5wSN/Vattal4YtZ6fpBlIUqONV4o/cOBX39cFfQSUCBrIXIjQ6RmapQCHK/PvBYw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "@storybook/instrumenter": "8.6.15",
@@ -16584,7 +16909,6 @@
       "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -17404,7 +17728,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -18467,8 +18790,7 @@
       "version": "20.5.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.1.tgz",
       "integrity": "sha512-4tT2UrL5LBqDwoed9wZ6N3umC4Yhz3W3FloMmiiG4JwmUJWpie0c7lcnUNd4gtMKuDEO4wRVS8B6Xa0uMRsMKg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/node-forge": {
       "version": "1.3.14",
@@ -18523,7 +18845,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
       "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -18690,8 +19011,7 @@
       "version": "13.15.10",
       "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.15.10.tgz",
       "integrity": "sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "7.4.7",
@@ -18773,7 +19093,6 @@
       "integrity": "sha512-nm3cvFN9SqZGXjmw5bZ6cGmvJSyJPn0wU9gHAZZHDnZl2wF9PhHv78Xf06E0MaNk4zLVHL8hb2/c32XvyJOLQg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.1",
         "@typescript-eslint/types": "8.53.1",
@@ -19377,7 +19696,6 @@
       "integrity": "sha512-tJxiPrWmzH8a+w9nLKlQMzAKX/7VjFs50MWgcAj7p9XQ7AQ9/35fByFYptgPELyLw+0aixTnC4pUWV+APcZ/kw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@testing-library/dom": "^10.4.0",
         "@testing-library/user-event": "^14.6.1",
@@ -19626,7 +19944,6 @@
       "integrity": "sha512-hGISOaP18plkzbWEcP/QvtRW1xDXF2+96HbEX6byqQhAUbiS5oH6/9JwW+QsQCIYON2bI6QZBF+2PvOmrRZ9wA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "3.2.4",
         "fflate": "^0.8.2",
@@ -19795,7 +20112,6 @@
       "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.27.tgz",
       "integrity": "sha512-sHZu9QyDPeDmN/MRoshhggVOWE5WlGFStKFwu8G52swATgSny27hJRWteKDSUUzUH+wp+bmeNbhJnEAel/auUQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.28.5",
         "@vue/compiler-core": "3.5.27",
@@ -20035,6 +20351,10 @@
     },
     "node_modules/@web-loom/i18n-core": {
       "resolved": "packages/i18n-core",
+      "link": true
+    },
+    "node_modules/@web-loom/mcp-server": {
+      "resolved": "packages/mcp-server",
       "link": true
     },
     "node_modules/@web-loom/media-core": {
@@ -20657,7 +20977,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -20756,9 +21075,7 @@
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-      "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -20991,7 +21308,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/array-ify": {
@@ -21876,7 +22192,6 @@
       "version": "1.20.4",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
       "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -21901,7 +22216,6 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -21911,7 +22225,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/bonjour-service": {
@@ -21999,7 +22312,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -22257,7 +22569,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -22271,7 +22582,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -22518,7 +22828,6 @@
       "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
       "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
@@ -23255,7 +23564,6 @@
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
       "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "5.2.1"
@@ -23268,7 +23576,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -23329,7 +23636,6 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
       "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -23339,7 +23645,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
       "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cookies": {
@@ -23360,7 +23665,7 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-2.0.6.tgz",
       "integrity": "sha512-1j20GZTsvKNkc4BY3NpMOM8tt///wY3FpIzozTOFO2ffuZcV61nojHXVKIy3WM+7ADCy5FVhdZYHYDdgTU0yJw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-what": "^3.14.1"
@@ -23532,7 +23837,6 @@
       "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "import-fresh": "^3.3.0",
         "js-yaml": "^4.1.0",
@@ -23881,7 +24185,6 @@
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -24427,8 +24730,7 @@
       "version": "0.0.1534754",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1534754.tgz",
       "integrity": "sha512-26T91cV5dbOYnXdJi5qQHoTtUoNEqwkHcAyu/IKtjIAxiEqPMrDiRkDOPWVsGfNZGmlQVHQbZRSjD8sxagWVsQ==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/diff": {
       "version": "4.0.2",
@@ -24634,7 +24936,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -24862,7 +25163,6 @@
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
       "integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -24970,7 +25270,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -24980,7 +25279,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -25046,7 +25344,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -25141,7 +25438,6 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -25228,7 +25524,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25245,7 +25540,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25262,7 +25556,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25279,7 +25572,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25296,7 +25588,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25313,7 +25604,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25330,7 +25620,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25347,7 +25636,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25364,7 +25652,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25381,7 +25668,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25398,7 +25684,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25415,7 +25700,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25432,7 +25716,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25449,7 +25732,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25466,7 +25748,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25483,7 +25764,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25500,7 +25780,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25517,7 +25796,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25534,7 +25812,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25551,7 +25828,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25568,7 +25844,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25585,7 +25860,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25602,7 +25876,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25619,7 +25892,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25636,7 +25908,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25653,7 +25924,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -25727,7 +25997,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -25956,7 +26225,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -26579,6 +26847,27 @@
         "bare-events": "^2.7.0"
       }
     },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/exec-async": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/exec-async/-/exec-async-2.2.0.tgz",
@@ -26725,7 +27014,6 @@
       "resolved": "https://registry.npmjs.org/expo/-/expo-53.0.25.tgz",
       "integrity": "sha512-KMaIMAd0vKl2ooiDB9XMKTuRAhSmrLdPOEON8Ck9mPmSrJB1FHBs6gb63d5IJTQAE1jBZLZj0JBg6rqRBOrTjg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "@expo/cli": "0.24.23",
@@ -26813,7 +27101,6 @@
       "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-13.3.2.tgz",
       "integrity": "sha512-wUlMdpqURmQ/CNKK/+BIHkDA5nGjMqNlYmW0pJFXY/KE/OG80Qcavdu2sHsL4efAIiNGvYdBS10WztuQYU4X0A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fontfaceobserver": "^2.1.0"
       },
@@ -26892,7 +27179,6 @@
       "version": "4.22.1",
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
@@ -26935,11 +27221,28 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/express/node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -26949,7 +27252,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/exsolve": {
@@ -27116,7 +27418,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
       "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -27325,7 +27626,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
       "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
@@ -27344,7 +27644,6 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
@@ -27354,7 +27653,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/find-cache-dir": {
@@ -27490,7 +27788,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -27721,7 +28018,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -27755,7 +28051,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -27800,7 +28095,7 @@
       "version": "4.13.0",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz",
       "integrity": "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -28034,7 +28329,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -28167,7 +28461,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -28445,6 +28738,15 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
+    },
+    "node_modules/hono": {
+      "version": "4.12.26",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.26.tgz",
+      "integrity": "sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
     },
     "node_modules/hosted-git-info": {
       "version": "4.1.0",
@@ -28805,7 +29107,6 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
@@ -28906,7 +29207,6 @@
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz",
       "integrity": "sha512-6TDAlDPZxUFCv+fuOkIoXT/V/f3Qbq8e37p+YOiYrUv3v9cc3/6x78VdfPgFVaB9dZYeLUfKgHRebpkm/oP2VQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "bin": {
@@ -29172,9 +29472,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -29194,7 +29494,6 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
@@ -29455,7 +29754,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -29510,7 +29809,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -29726,6 +30025,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -29924,7 +30229,7 @@
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/is-what/-/is-what-3.14.1.tgz",
       "integrity": "sha512-sNxgpk9793nzSs7bA6JQJGeIuRBQhAaNGG77kzYQgMkrID+lS6SlK07K5LaptscDlSaIgH+GPFzf+d75FVxozA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/is-wsl": {
@@ -30351,9 +30656,8 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -30363,6 +30667,15 @@
       "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
       "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
       "license": "MIT"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/js-beautify": {
       "version": "1.15.4",
@@ -30532,6 +30845,12 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -30924,9 +31243,8 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/less/-/less-4.2.2.tgz",
       "integrity": "sha512-tkuLHQlvWUTeQ3doAqnHbNn8T6WX1KA8yvbKG9x4VtKtIjHsVKQZCH11zRgAfbDAXC2UNIg/K9BYAAcEzUIrNg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "copy-anything": "^2.0.1",
         "parse-node-version": "^1.0.1",
@@ -30979,7 +31297,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
       "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -30994,7 +31311,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
       "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -31005,7 +31321,6 @@
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
       "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "bin": {
@@ -31016,7 +31331,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "optional": true,
       "engines": {
@@ -31093,9 +31407,8 @@
       "version": "1.30.2",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.2.tgz",
       "integrity": "sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MPL-2.0",
-      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -31127,7 +31440,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -31148,7 +31460,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -31169,7 +31480,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -31190,7 +31500,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -31211,7 +31520,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -31232,7 +31540,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -31253,7 +31560,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -31274,7 +31580,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -31295,7 +31600,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -31316,7 +31620,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -31337,7 +31640,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -32287,7 +32589,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -32602,7 +32903,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -32706,7 +33006,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
       "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -32732,7 +33031,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -34537,7 +34835,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/needle/-/needle-3.3.1.tgz",
       "integrity": "sha512-6k0YULvhpw+RoLNiQCRKOl09Rv1dPLr8hHnVjHqdolKwDrdNyk+Hmrthi4lIGPPz3r39dLx0hsF5s40sZ3Us4Q==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -34555,7 +34852,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -34675,7 +34971,6 @@
       "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
       "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
         "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
@@ -38035,7 +38330,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -38235,7 +38529,6 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -39023,7 +39316,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parse-node-version/-/parse-node-version-1.0.1.tgz",
       "integrity": "sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
@@ -39204,7 +39497,6 @@
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-type": {
@@ -39325,6 +39617,15 @@
       },
       "bin": {
         "pixelmatch": "bin/pixelmatch"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/pkg-dir": {
@@ -39510,7 +39811,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -39783,7 +40083,6 @@
       "integrity": "sha512-yEPsovQfpxYfgWNhCfECjG5AQaO+K3dp6XERmOepyPDVqcJm+bjyCVO3pmU+nAPe0N5dDvekfGezt/EIiRe1TA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -40062,7 +40361,6 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "forwarded": "0.2.0",
@@ -40110,7 +40408,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
       "integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -40234,7 +40531,6 @@
       "version": "6.14.1",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
       "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -40361,7 +40657,6 @@
       "version": "2.5.3",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
       "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -40487,7 +40782,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -40519,7 +40813,6 @@
       "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.79.6.tgz",
       "integrity": "sha512-kvIWSmf4QPfY41HC25TR285N7Fv0Pyn3DAEK8qRL9dA35usSaxsJkHfw+VqnonqJjXOaoKCEanwudRAJ60TBGA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^29.7.0",
         "@react-native/assets-registry": "0.79.6",
@@ -40605,7 +40898,6 @@
       "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.24.0.tgz",
       "integrity": "sha512-ZdWyOd1C8axKJHIfYxjJKCcxjWEpUtUWgTOVY2wynbiveSQDm8X/PDyAKXSer/GOtIpjudUbACOndZXCN3vHsw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@egjs/hammerjs": "^2.0.17",
         "hoist-non-react-statics": "^3.3.0",
@@ -40631,7 +40923,6 @@
       "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.4.0.tgz",
       "integrity": "sha512-JaEThVyJcLhA+vU0NU8bZ0a1ih6GiF4faZ+ArZLqpYbL6j7R3caRqj+mE3lEtKCuHgwjLg3bCxLL1GPUJZVqUA==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
@@ -40642,7 +40933,6 @@
       "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.11.1.tgz",
       "integrity": "sha512-F0zOzRVa3ptZfLpD0J8ROdo+y1fEPw+VBFq1MTY/iyDu08al7qFUO5hLMd+EYMda5VXGaTFCa8q7bOppUszhJw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "react-freeze": "^1.0.0",
         "react-native-is-edge-to-edge": "^1.1.7",
@@ -40658,7 +40948,6 @@
       "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-15.15.1.tgz",
       "integrity": "sha512-ZUD1xwc3Hwo4cOmOLumjJVoc7lEf9oQFlHnLmgccLC19fNm6LVEdtB+Cnip6gEi0PG3wfvVzskViEtrySQP8Fw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "css-select": "^5.1.0",
         "css-tree": "^1.1.3",
@@ -41252,8 +41541,7 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -41723,7 +42011,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -41956,6 +42244,32 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/rrweb-cssom": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
@@ -42015,7 +42329,6 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -42112,7 +42425,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/sass": {
@@ -42121,7 +42433,6 @@
       "integrity": "sha512-3ToiC1xZ1Y8aU7+CkgCI/tqyuPXEmYGJXO7H4uqp0xkLXUqp88rQQ4j1HmP37xSJLbCJPaIiv+cT1y+grssrww==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -42784,7 +43095,6 @@
       "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.21.0.tgz",
       "integrity": "sha512-N65B/3bqL/TI2crrXr+4UivctrAGEjmsib5rPMMPpFp1xAx/w03v8WZ9RDDFYteXoEgY7qZ4HGgl5KBIu1153w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@shikijs/core": "3.21.0",
         "@shikijs/engine-javascript": "3.21.0",
@@ -42800,7 +43110,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -42820,7 +43129,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -42837,7 +43145,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -42856,7 +43163,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -43486,7 +43792,6 @@
       "integrity": "sha512-Ob7DMlwWx8s7dMvcQ3xPc02TvUeralb+xX3oaPRk9wY9Hc6M1IBC/7cEoITkSmRS2v38DHubC+mtEKNc1u2gQg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@storybook/core": "8.6.15"
       },
@@ -44059,8 +44364,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
       "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.3.0",
@@ -44176,7 +44480,6 @@
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.39.0.tgz",
       "integrity": "sha512-LBAhFyLho16harJoWMg/nZsQYgTrg5jXOn2nCYjRUcZZEdE3qa2zb8QEDRUGVZBW4rlazf2fxkg8tztybTaqWw==",
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.8.2",
@@ -44682,7 +44985,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -44740,8 +45042,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tsscmp": {
       "version": "1.0.6",
@@ -44757,9 +45058,8 @@
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -44781,7 +45081,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -44798,7 +45097,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -44815,7 +45113,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -44832,7 +45129,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -44849,7 +45145,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -44866,7 +45161,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -44883,7 +45177,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -44900,7 +45193,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -44917,7 +45209,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -44934,7 +45225,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -44951,7 +45241,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -44968,7 +45257,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -44985,7 +45273,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -45002,7 +45289,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -45019,7 +45305,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -45036,7 +45321,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -45053,7 +45337,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -45070,7 +45353,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -45087,7 +45369,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -45104,7 +45385,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -45121,7 +45401,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -45138,7 +45417,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -45155,7 +45433,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -45169,7 +45446,7 @@
       "version": "0.27.2",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
       "integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -45463,7 +45740,6 @@
       "integrity": "sha512-7Imdmg37joOloTnj+DPrab9hIaQcDdJ5RwSzcauo/wMOSAgO+A/I/8b3hsGGs6PWQz70m/jkPgdqWsfNKtwwDQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "turbo": "bin/turbo"
       },
@@ -45599,7 +45875,6 @@
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
       "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "media-typer": "0.3.0",
@@ -45705,7 +45980,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
       "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -46379,7 +46653,6 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -46909,7 +47182,6 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.27.tgz",
       "integrity": "sha512-aJ/UtoEyFySPBGarREmN4z6qNKpbEguYHMmXSiOGk69czc+zhs0NF6tEFrY8TZKAl8N/LYAkd4JHVd5E/AsSmw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.27",
         "@vue/compiler-sfc": "3.5.27",
@@ -46949,7 +47221,6 @@
       "integrity": "sha512-CydUvFOQKD928UzZhTp4pr2vWz1L+H99t7Pkln2QSPdvmURT0MoC4wUccfCnuEaihNsu9aYYyk+bep8rlfkUXw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "eslint-scope": "^8.2.0",
@@ -47178,7 +47449,6 @@
       "integrity": "sha512-UFynvx+gM44Gv9qFgj0acCQK2VE1CtdfwFdimkapco3hlPCJ/zeq73n2yVKimVbtm+TnApIugGhLJnkU6gjYXA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.6",
@@ -47256,7 +47526,6 @@
       "integrity": "sha512-QcQ72gh8a+7JO63TAx/6XZf/CWhgMzu5m0QirvPfGvptOusAxG12w2+aua1Jkjr7hzaWDnJ2n6JFeexMHI+Zjg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.13",
         "@types/connect-history-api-fallback": "^1.5.4",
@@ -47978,7 +48247,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -48117,9 +48385,17 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     },
     "node_modules/zod-validation-error": {
@@ -48139,8 +48415,7 @@
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.15.1.tgz",
       "integrity": "sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/zwitch": {
       "version": "2.0.4",
@@ -48541,7 +48816,6 @@
       "version": "18.3.27",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -48598,7 +48872,6 @@
       "version": "18.3.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -48610,7 +48883,6 @@
       "version": "18.3.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -48758,7 +49030,6 @@
       "version": "5.7.3",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -48853,6 +49124,37 @@
     },
     "packages/i18n-core/node_modules/typescript": {
       "version": "5.7.3",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "packages/mcp-server": {
+      "name": "@web-loom/mcp-server",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "zod": "^3.25.67"
+      },
+      "bin": {
+        "web-loom-mcp": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/node": "^20.x.x",
+        "typescript": "~5.7.3",
+        "vitest": "^3.2.4"
+      }
+    },
+    "packages/mcp-server/node_modules/typescript": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -48984,7 +49286,6 @@
       "version": "18.3.27",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -49041,7 +49342,6 @@
       "version": "18.3.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -49053,7 +49353,6 @@
       "version": "18.3.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -49166,7 +49465,6 @@
       "version": "5.7.3",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -49439,7 +49737,6 @@
       "integrity": "sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -50229,7 +50526,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -50959,7 +51255,6 @@
       "version": "18.3.27",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -51016,7 +51311,6 @@
       "version": "18.3.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -51028,7 +51322,6 @@
       "version": "18.3.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -51424,7 +51717,6 @@
       "integrity": "sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -1,0 +1,166 @@
+# @web-loom/mcp-server
+
+MCP (Model Context Protocol) server for the web-loom framework. Gives AI assistants structured tools to scaffold `@web-loom/*` code, read package documentation, and guide common MVVM workflows.
+
+## Installation
+
+```bash
+npm install -g @web-loom/mcp-server
+```
+
+Or run directly without installing:
+
+```bash
+npx @web-loom/mcp-server
+```
+
+## Setup with Claude Code
+
+**Global** (available in all projects):
+```bash
+claude mcp add web-loom -- npx @web-loom/mcp-server
+```
+
+**Project-scoped** (creates `.mcp.json` in the repo root):
+```bash
+claude mcp add --scope project web-loom -- npx @web-loom/mcp-server
+```
+
+**From the monorepo** (after `npm run build`):
+```bash
+claude mcp add web-loom -- node packages/mcp-server/dist/index.js
+```
+
+## Capabilities
+
+### Tools
+
+#### Scaffolding
+
+| Tool | What it generates |
+|------|-------------------|
+| `scaffold_model` | Zod schema + `RestfulApiModel` subclass |
+| `scaffold_viewmodel` | `RestfulApiViewModel` subclass with optional custom commands |
+| `scaffold_restful_feature` | Full feature: model + viewmodel + framework adapter |
+| `scaffold_command` | Standalone `Command<P,R>` or `CompositeCommand` |
+| `scaffold_plugin` | `PluginManifest` + `PluginModule` with lifecycle hooks |
+| `scaffold_form` | `FormFactory` setup with Zod validation |
+
+#### Knowledge
+
+| Tool | What it returns |
+|------|----------------|
+| `explain_pattern` | Code example for a named pattern |
+| `list_packages` | Catalog of all `@web-loom/*` packages |
+| `select_package` | Package recommendation for a described use case |
+
+**`scaffold_restful_feature`** is the most powerful tool — it returns all four files for a complete MVVM feature in one call:
+
+```
+scaffold_restful_feature({
+  name: "Product",
+  endpoint: "/products",
+  fields: [
+    { name: "title", type: "string" },
+    { name: "price", type: "number" },
+    { name: "inStock", type: "boolean", optional: true }
+  ],
+  framework: "react"   // "react" | "vue" | "vanilla" | "angular"
+})
+```
+
+Returns `ProductModel.ts`, `ProductViewModel.ts`, and `useProduct.ts` with correct types, Zod schema, dispose pattern, and `useObservable` wiring.
+
+**`explain_pattern`** supports these pattern names:
+
+`mvvm` · `command` · `observable` · `dispose-pattern` · `plugin` · `store` · `forms` · `query` · `composite-command`
+
+### Resources
+
+Resources expose live documentation that AI assistants can read as context.
+
+| URI | Content |
+|-----|---------|
+| `web-loom://docs/mvvm-core` | `@web-loom/mvvm-core` README |
+| `web-loom://docs/query-core` | `@web-loom/query-core` README |
+| `web-loom://docs/store-core` | `@web-loom/store-core` README |
+| `web-loom://docs/ui-core` | `@web-loom/ui-core` README |
+| `web-loom://docs/forms-core` | `@web-loom/forms-core` README |
+| `web-loom://docs/plugin-core` | `@web-loom/plugin-core` README |
+| `web-loom://docs/event-bus-core` | `@web-loom/event-bus-core` README |
+| `web-loom://docs/http-core` | `@web-loom/http-core` README |
+| `web-loom://docs/router-core` | `@web-loom/router-core` README |
+| `web-loom://docs/storage-core` | `@web-loom/storage-core` README |
+| `web-loom://docs/i18n-core` | `@web-loom/i18n-core` README |
+| `web-loom://docs/notifications-core` | `@web-loom/notifications-core` README |
+| `web-loom://architecture/mvvm` | Embedded MVVM layer reference and anti-pattern guide |
+
+README resources are read from the installed packages at request time, so they stay current with the installed version.
+
+### Prompts
+
+Guided prompt templates that instruct the AI through multi-step workflows.
+
+| Prompt | Arguments | What it does |
+|--------|-----------|--------------|
+| `create-mvvm-feature` | `featureName`, `endpoint`, `fields`, `framework` | Walks through schema → model → viewmodel → adapter in order |
+| `debug-viewmodel` | `code`, `symptom?` | Reviews a ViewModel for missing dispose, leaked subscriptions, incorrect canExecute wiring, UI state in Model |
+| `migrate-to-web-loom` | `code`, `framework` | Maps existing component code to Model / ViewModel / View layers |
+
+## Generated Code Conventions
+
+All scaffolding tools enforce the patterns from the live codebase:
+
+**Model** — Zod schema first, type inference second, class third:
+```typescript
+const ProductSchema = z.object({ id: z.string(), title: z.string(), price: z.number() });
+export type ProductData = z.infer<typeof ProductSchema>;
+export const ProductListSchema = z.array(ProductSchema);
+
+export class ProductModel extends RestfulApiModel<ProductListData, typeof ProductListSchema> {
+  constructor(apiBase = "http://localhost:3000") {
+    super({ baseUrl: apiBase, endpoint: "/products", fetcher, schema: ProductListSchema, initialData: [] });
+  }
+}
+```
+
+**ViewModel** — extends `RestfulApiViewModel`, registers custom commands, always overrides `dispose`:
+```typescript
+export class ProductViewModel extends RestfulApiViewModel<ProductListData, typeof ProductListSchema> {
+  public readonly archiveCommand = this.registerCommand(
+    new Command<string, void>(async (id) => { /* ... */ })
+  );
+  constructor(model: ProductModel) { super(model); }
+  public override dispose(): void { super.dispose(); }
+}
+```
+
+**React adapter** — `useObservable`, single `useState` for the VM instance, dispose on unmount:
+```typescript
+export function useProduct() {
+  const [vm] = useState(() => new ProductViewModel(new ProductModel()));
+  const data = useObservable(vm.data$, null);
+  const isLoading = useObservable(vm.isLoading$, false);
+  useEffect(() => { vm.fetchCommand.execute(); return () => vm.dispose(); }, [vm]);
+  return { data, isLoading, vm };
+}
+```
+
+## Development
+
+```bash
+# Build
+npm run build
+
+# Watch mode
+npm run dev
+
+# Type check
+npm run check-types
+```
+
+The server uses Node.js stdio transport (stdin/stdout MCP protocol). It has no dependency on RxJS or any `@web-loom/*` runtime — it only generates code strings, keeping the bundle small.
+
+## License
+
+MIT

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@web-loom/mcp-server",
+  "description": "MCP server for the web-loom framework — scaffolding, docs, and guided patterns for @web-loom/* packages.",
+  "author": "Festus Yeboah<festus.yeboah@hotmail.com>",
+  "license": "MIT",
+  "private": false,
+  "version": "0.1.0",
+  "type": "module",
+  "files": ["dist"],
+  "bin": {
+    "web-loom-mcp": "./dist/index.js"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "types": "./dist/index.d.ts",
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "web-loom",
+    "mvvm",
+    "scaffolding",
+    "ai",
+    "claude"
+  ],
+  "scripts": {
+    "build": "tsc --project tsconfig.build.json && node scripts/make-executable.js",
+    "dev": "tsc --project tsconfig.build.json --watch",
+    "test": "vitest --watch=false",
+    "test:watch": "vitest --watch",
+    "lint": "eslint . --ext .ts,.js",
+    "check-types": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "zod": "^3.25.67"
+  },
+  "devDependencies": {
+    "@types/node": "^20.x.x",
+    "typescript": "~5.7.3",
+    "vitest": "^3.2.4"
+  }
+}

--- a/packages/mcp-server/scripts/make-executable.js
+++ b/packages/mcp-server/scripts/make-executable.js
@@ -1,0 +1,13 @@
+import { chmodSync, readFileSync, writeFileSync } from "fs";
+import { fileURLToPath } from "url";
+import { join, dirname } from "path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const entryPath = join(__dirname, "../dist/index.js");
+
+// Prepend shebang so the bin works without `node` prefix
+const content = readFileSync(entryPath, "utf8");
+if (!content.startsWith("#!")) {
+  writeFileSync(entryPath, `#!/usr/bin/env node\n${content}`);
+}
+chmodSync(entryPath, 0o755);

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -1,0 +1,49 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+
+import { registerDocsResources } from "./resources/docs.js";
+import { registerArchitectureResource } from "./resources/architecture.js";
+
+import { registerScaffoldModelTool } from "./tools/scaffold-model.js";
+import { registerScaffoldViewModelTool } from "./tools/scaffold-viewmodel.js";
+import { registerScaffoldFeatureTool } from "./tools/scaffold-feature.js";
+import { registerScaffoldCommandTool } from "./tools/scaffold-command.js";
+import { registerScaffoldPluginTool } from "./tools/scaffold-plugin.js";
+import { registerScaffoldFormTool } from "./tools/scaffold-form.js";
+import { registerExplainPatternTool } from "./tools/explain-pattern.js";
+import { registerListPackagesTool } from "./tools/list-packages.js";
+import { registerSelectPackageTool } from "./tools/select-package.js";
+
+import { registerCreateMvvmFeaturePrompt } from "./prompts/create-mvvm-feature.js";
+import { registerDebugViewModelPrompt } from "./prompts/debug-viewmodel.js";
+import { registerMigrateToWebLoomPrompt } from "./prompts/migrate-to-web-loom.js";
+
+const server = new McpServer({
+  name: "@web-loom/mcp-server",
+  version: "0.1.0",
+});
+
+// Resources
+registerDocsResources(server);
+registerArchitectureResource(server);
+
+// Scaffolding tools
+registerScaffoldModelTool(server);
+registerScaffoldViewModelTool(server);
+registerScaffoldFeatureTool(server);
+registerScaffoldCommandTool(server);
+registerScaffoldPluginTool(server);
+registerScaffoldFormTool(server);
+
+// Knowledge tools
+registerExplainPatternTool(server);
+registerListPackagesTool(server);
+registerSelectPackageTool(server);
+
+// Guided prompts
+registerCreateMvvmFeaturePrompt(server);
+registerDebugViewModelPrompt(server);
+registerMigrateToWebLoomPrompt(server);
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/packages/mcp-server/src/prompts/create-mvvm-feature.ts
+++ b/packages/mcp-server/src/prompts/create-mvvm-feature.ts
@@ -1,0 +1,63 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+export function registerCreateMvvmFeaturePrompt(server: McpServer): void {
+  server.registerPrompt(
+    "create-mvvm-feature",
+    {
+      description: "Step-by-step guide for creating a complete MVVM feature using web-loom — from Zod schema through Model, ViewModel, to framework adapter.",
+      argsSchema: {
+        featureName: z.string().describe("Feature/entity name in PascalCase (e.g. 'Product', 'Invoice')"),
+        endpoint: z.string().describe("REST API endpoint (e.g. '/api/products')"),
+        fields: z.string().describe("Comma-separated field names and types, e.g. 'name:string, price:number, active:boolean'"),
+        framework: z.enum(["react", "vue", "vanilla", "angular"]).describe("Target UI framework"),
+      },
+    },
+    async ({ featureName, endpoint, fields, framework }) => ({
+      messages: [
+        {
+          role: "user" as const,
+          content: {
+            type: "text" as const,
+            text: `I want to create a web-loom MVVM feature called "${featureName}" that connects to "${endpoint}".
+
+**Fields**: ${fields}
+**Framework**: ${framework}
+
+Please follow these steps in order:
+
+## Step 1 — Scaffold the Model
+Use the \`scaffold_model\` tool with:
+- name: "${featureName}"
+- endpoint: "${endpoint}"
+- fields: parse from "${fields}"
+
+## Step 2 — Scaffold the ViewModel
+Use the \`scaffold_viewmodel\` tool with:
+- name: "${featureName}"
+- modelClass: "${featureName}Model"
+
+## Step 3 — Scaffold the Full Feature (Model + ViewModel + Framework Adapter)
+Use the \`scaffold_restful_feature\` tool to get all files at once:
+- name: "${featureName}"
+- endpoint: "${endpoint}"
+- fields: (same as above)
+- framework: "${framework}"
+
+## Step 4 — Review Architecture
+After generating, verify:
+1. The Model extends \`RestfulApiModel\` with the correct Zod schema
+2. The ViewModel extends \`RestfulApiViewModel\` and calls \`super.dispose()\`
+3. The ${framework} adapter disposes the ViewModel on unmount
+4. Any custom commands are registered via \`this.registerCommand()\`
+
+## Step 5 — Integration
+Read \`web-loom://architecture/mvvm\` for the full integration guide.
+
+Start with Step 1 now.`,
+          },
+        },
+      ],
+    })
+  );
+}

--- a/packages/mcp-server/src/prompts/debug-viewmodel.ts
+++ b/packages/mcp-server/src/prompts/debug-viewmodel.ts
@@ -1,0 +1,61 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+export function registerDebugViewModelPrompt(server: McpServer): void {
+  server.registerPrompt(
+    "debug-viewmodel",
+    {
+      description: "Diagnose common issues in a web-loom ViewModel — missing dispose, leaked subscriptions, incorrect canExecute wiring, UI state in Model.",
+      argsSchema: {
+        code: z.string().describe("The ViewModel (and optionally its Model) source code to review"),
+        symptom: z
+          .string()
+          .optional()
+          .describe("Describe the problem you are seeing (e.g. 'memory leak', 'command never enables', 'data not updating')"),
+      },
+    },
+    async ({ code, symptom }) => ({
+      messages: [
+        {
+          role: "user" as const,
+          content: {
+            type: "text" as const,
+            text: [
+              "Please review this web-loom ViewModel code for issues.",
+              symptom ? `\n**Reported symptom**: ${symptom}\n` : "",
+              "\n```typescript",
+              code,
+              "```",
+              "\nCheck for these common anti-patterns in order:",
+              "",
+              "### 1. Dispose Pattern",
+              "- Does the ViewModel call `super.dispose()` in its `dispose()` override?",
+              "- Are all custom commands registered via `this.registerCommand()` (not stored as plain properties)?",
+              "- Are manual subscriptions added via `this.addSubscription()` or piped with `takeUntil(this._destroy$)`?",
+              "- Does the View/caller actually call `vm.dispose()` on unmount?",
+              "",
+              "### 2. Command Wiring",
+              "- Is `canExecute$` correctly derived? (e.g. `this.isLoading$.pipe(map(l => !l))`)",
+              "- Does `canExecute$` emit an initial `true` so the command isn't disabled at start?",
+              "- Are async operations inside `execute` wrapped in try/catch so `isExecuting$` resets on error?",
+              "",
+              "### 3. Model / Store Separation",
+              "- Is business data (entities, loading state, errors) in the Model, not in Store?",
+              "- Is UI-only state (which panel is open, current theme) in Store, not in the Model?",
+              "",
+              "### 4. Observable Contract",
+              "- Are Subjects exposed as read-only Observables (`asObservable()`) to ViewModels and Views?",
+              "- Are derived observables (`combineLatest`, `map`, etc.) memoized as class properties, not recreated on each access?",
+              "",
+              "### 5. Lifecycle",
+              "- Is the ViewModel instantiated once (not inside a render loop)?",
+              "- Is `fetchCommand.execute()` called in the right lifecycle hook (after the View mounts, not during construction)?",
+              "",
+              "Report each finding as: **[ISSUE]** description → **[FIX]** corrected code snippet.",
+            ].join("\n"),
+          },
+        },
+      ],
+    })
+  );
+}

--- a/packages/mcp-server/src/prompts/migrate-to-web-loom.ts
+++ b/packages/mcp-server/src/prompts/migrate-to-web-loom.ts
@@ -1,0 +1,67 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+export function registerMigrateToWebLoomPrompt(server: McpServer): void {
+  server.registerPrompt(
+    "migrate-to-web-loom",
+    {
+      description: "Step-by-step migration guide from plain framework code (React useState/useEffect, Vue refs, vanilla JS) to the web-loom MVVM pattern.",
+      argsSchema: {
+        code: z.string().describe("The existing code to migrate (React component, Vue SFC, plain JS module, etc.)"),
+        framework: z
+          .enum(["react", "vue", "vanilla", "angular"])
+          .describe("The source framework of the code"),
+      },
+    },
+    async ({ code, framework }) => ({
+      messages: [
+        {
+          role: "user" as const,
+          content: {
+            type: "text" as const,
+            text: [
+              `Migrate this ${framework} code to the web-loom MVVM pattern.\n`,
+              "```typescript",
+              code,
+              "```",
+              "",
+              "## Migration Steps",
+              "",
+              "### Step 1 — Identify the Data Layer",
+              "Find all data fetching, state variables, and API calls. These become the **Model**:",
+              "- `useState<User[]>([])` / `const users = ref([])` → `BaseModel.data$`",
+              "- `setLoading(true)` / loading flags → `BaseModel.isLoading$`",
+              "- `setError(e)` / error state → `BaseModel.error$`",
+              "- `fetch('/api/users')` calls → move into `RestfulApiModel` or a custom `BaseModel` method",
+              "",
+              "### Step 2 — Identify the Business Logic Layer",
+              "Find all event handlers, derived state, and orchestration. These become the **ViewModel**:",
+              "- `onClick` handlers → `Command.execute()`",
+              "- Loading guards (`if (isLoading) return`) → `canExecute$` on Commands",
+              "- Derived values (`const total = items.reduce(...)`) → computed observables with `map`/`combineLatest`",
+              "- Multi-step operations → `CompositeCommand`",
+              "",
+              "### Step 3 — Scaffold the Files",
+              "Run `scaffold_restful_feature` if the code does CRUD, or use `scaffold_model` + `scaffold_viewmodel` separately.",
+              "",
+              "### Step 4 — Rewrite the View",
+              "The View keeps only rendering logic:",
+              framework === "react"
+                ? "- Replace `useState` + `useEffect` with `useObservable(vm.data$, [])` and `useObservable(vm.isLoading$, false)`\n- Add `useEffect(() => { vm.fetchCommand.execute(); return () => vm.dispose(); }, [vm])`\n- Bind button `onClick` to `() => vm.yourCommand.execute(param)`\n- Disable buttons with `useObservable(vm.yourCommand.canExecute$, true)` negated"
+                : framework === "vue"
+                  ? "- Replace `ref`/`reactive` with subscriptions to `vm.data$`, `vm.isLoading$`\n- Call `vm.fetchCommand.execute()` in `onMounted`\n- Call `vm.dispose()` in `onUnmounted`\n- Bind `@click` to `() => vm.yourCommand.execute(param)`"
+                  : framework === "angular"
+                    ? "- Move data fetching to an `@Injectable` service holding the ViewModel\n- Use `async` pipe in templates with `vm.data$ | async`\n- Implement `OnDestroy` and call `vm.dispose()` in `ngOnDestroy`"
+                    : "- Subscribe to observables manually: `vm.data$.subscribe(data => renderList(data))`\n- Call `vm.fetchCommand.execute()` on init\n- Store unsubscribe functions and call them + `vm.dispose()` on cleanup",
+              "",
+              "### Step 5 — Verify the Dispose Pattern",
+              "Confirm the View's unmount hook calls `vm.dispose()`. This is the most commonly missed step.",
+              "",
+              "Now produce the migrated code for each layer (Model, ViewModel, View) based on the code above.",
+            ].join("\n"),
+          },
+        },
+      ],
+    })
+  );
+}

--- a/packages/mcp-server/src/resources/architecture.ts
+++ b/packages/mcp-server/src/resources/architecture.ts
@@ -1,0 +1,236 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+const MVVM_ARCHITECTURE_DOC = `# Web-Loom MVVM Architecture Reference
+
+## Layer Overview
+
+\`\`\`
+View (framework-specific)
+  ↓ subscribes to observables
+ViewModel (framework-agnostic business logic)
+  ↓ uses
+Model (data & API layer)
+  ↓ calls
+Infrastructure (HTTP, Storage, i18n, etc.)
+\`\`\`
+
+Cross-cutting concerns (used across all layers):
+- **EventBus** — cross-feature pub-sub
+- **Store** — UI-only state (theme, sidebar, modal visibility)
+- **Router** — navigation state
+- **Notifications** — user feedback
+
+**Rule**: Business data (entities, loading state, errors) lives in Models. UI-only state (which panel is open) lives in Store.
+
+---
+
+## BaseModel
+
+\`\`\`typescript
+import { BaseModel } from "@web-loom/mvvm-core";
+import { z } from "zod";
+
+const TodoSchema = z.object({ id: z.string(), text: z.string(), done: z.boolean() });
+type TodoData = z.infer<typeof TodoSchema>;
+const TodoListSchema = z.array(TodoSchema);
+
+class TodoModel extends BaseModel<TodoData[], typeof TodoListSchema> {
+  constructor() {
+    super({ schema: TodoListSchema, initialData: [] });
+  }
+
+  async loadTodos(): Promise<void> {
+    this.setLoading(true);
+    try {
+      const data = await fetch("/api/todos").then(r => r.json());
+      this.setData(data);
+    } catch (err) {
+      this.setError(err);
+    } finally {
+      this.setLoading(false);
+    }
+  }
+}
+\`\`\`
+
+Key observables: \`data$\`, \`isLoading$\`, \`error$\`, \`validationErrors$\`
+
+---
+
+## RestfulApiModel (preferred for CRUD)
+
+\`\`\`typescript
+import { RestfulApiModel } from "@web-loom/mvvm-core";
+
+class TodoListModel extends RestfulApiModel<TodoData[], typeof TodoListSchema> {
+  constructor() {
+    super({
+      baseUrl: "http://localhost:3000",
+      endpoint: "/todos",
+      fetcher: (url, opts) => fetch(url, opts).then(r => r.json()),
+      schema: TodoListSchema,
+      initialData: [],
+    });
+  }
+}
+// Built-in: fetch(), create(), update(), delete()
+\`\`\`
+
+---
+
+## BaseViewModel
+
+\`\`\`typescript
+import { BaseViewModel, Command } from "@web-loom/mvvm-core";
+
+class TodoViewModel extends BaseViewModel<TodoModel> {
+  // Custom command
+  public readonly loadCommand = this.registerCommand(
+    new Command(async () => { await this.model.loadTodos(); })
+  );
+
+  constructor(model: TodoModel) {
+    super(model);
+  }
+
+  public override dispose(): void {
+    super.dispose(); // always call super
+  }
+}
+\`\`\`
+
+---
+
+## RestfulApiViewModel (CRUD commands pre-built)
+
+\`\`\`typescript
+import { RestfulApiViewModel } from "@web-loom/mvvm-core";
+
+class TodoListViewModel extends RestfulApiViewModel<TodoData[], typeof TodoListSchema> {
+  // Pre-built: fetchCommand, createCommand, updateCommand, deleteCommand
+  // Pre-built: selectedItem$, selectItem()
+
+  constructor(model: TodoListModel) { super(model); }
+  public override dispose(): void { super.dispose(); }
+}
+\`\`\`
+
+---
+
+## Command Pattern
+
+\`\`\`typescript
+import { Command } from "@web-loom/mvvm-core";
+import { map } from "rxjs";
+
+// Basic
+const saveCommand = new Command<FormData, void>(
+  async (data) => { await api.save(data); }
+);
+
+// With canExecute tied to loading state
+const deleteCommand = new Command<string, void>(
+  async (id) => { await api.delete(id); },
+  this.isLoading$.pipe(map(loading => !loading)) // disable while loading
+);
+
+// Usage
+await saveCommand.execute(formData);
+saveCommand.isExecuting$   // Observable<boolean>
+saveCommand.canExecute$    // Observable<boolean>
+saveCommand.executeError$  // Observable<unknown>
+\`\`\`
+
+---
+
+## CompositeCommand
+
+\`\`\`typescript
+import { CompositeCommand } from "@web-loom/mvvm-core";
+
+const saveAll = new CompositeCommand({ executionMode: "parallel" });
+saveAll.register(saveProfileCommand);
+saveAll.register(saveSettingsCommand);
+
+await saveAll.execute(); // runs both in parallel
+saveAll.isExecuting$     // true while any child runs
+\`\`\`
+
+---
+
+## Dispose Pattern (mandatory)
+
+Every ViewModel MUST dispose to prevent memory leaks:
+
+\`\`\`typescript
+// React
+useEffect(() => {
+  vm.fetchCommand.execute();
+  return () => vm.dispose(); // cleanup on unmount
+}, [vm]);
+
+// Vue
+onUnmounted(() => vm.dispose());
+
+// Angular
+ngOnDestroy(): void { this.vm.dispose(); }
+\`\`\`
+
+---
+
+## ObservableCollection
+
+\`\`\`typescript
+import { ObservableCollection } from "@web-loom/mvvm-core";
+
+const items = new ObservableCollection<Todo>();
+items.add({ id: "1", text: "Buy milk", done: false });
+items.update("1", { done: true });
+items.remove("1");
+
+items.items$      // Observable<Todo[]>
+items.count$      // Observable<number>
+items.toArray()   // Todo[] snapshot
+\`\`\`
+
+---
+
+## Package Selection Guide
+
+| Need | Package |
+|------|---------|
+| CRUD entity with REST API | \`@web-loom/mvvm-core\` → RestfulApiModel + RestfulApiViewModel |
+| Custom data fetching with caching | \`@web-loom/query-core\` → QueryCore |
+| UI-only state (theme, panels) | \`@web-loom/store-core\` → createStore |
+| Headless UI behaviors | \`@web-loom/ui-core\` → createDialogBehavior, createListSelection, etc. |
+| Forms with validation | \`@web-loom/forms-core\` → FormFactory |
+| Plugin system | \`@web-loom/plugin-core\` → PluginRegistry |
+| Cross-feature events | \`@web-loom/event-bus-core\` |
+| Routing | \`@web-loom/router-core\` |
+| localStorage/sessionStorage | \`@web-loom/storage-core\` |
+
+---
+
+## Common Anti-Patterns to Avoid
+
+1. **Calling dispose in the wrong place** — always dispose in the View's unmount hook, not in the ViewModel itself.
+2. **Business data in Store** — Store is for UI state only (sidebar open, current theme). Entity data belongs in Models.
+3. **Missing registerCommand** — custom commands MUST be registered via \`this.registerCommand()\` so they are disposed automatically.
+4. **Subscribing without unsubscribing** — use \`this.addSubscription()\` in ViewModels so subscriptions are cleaned up on dispose.
+5. **Creating ViewModel inside render** — instantiate ViewModels once (useState, @Injectable, module-level), not on every render cycle.
+`;
+
+export function registerArchitectureResource(server: McpServer): void {
+  const uri = "web-loom://architecture/mvvm";
+  server.registerResource(
+    "architecture-mvvm",
+    uri,
+    {
+      description: "MVVM layer reference — BaseModel, BaseViewModel, RestfulApiModel, Command, dispose pattern, package selection guide",
+      mimeType: "text/markdown",
+    },
+    async (_uri) => ({
+      contents: [{ uri, text: MVVM_ARCHITECTURE_DOC, mimeType: "text/markdown" }],
+    })
+  );
+}

--- a/packages/mcp-server/src/resources/docs.ts
+++ b/packages/mcp-server/src/resources/docs.ts
@@ -1,0 +1,48 @@
+import { readFile } from "fs/promises";
+import { fileURLToPath } from "url";
+import { join, dirname } from "path";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const PACKAGES = [
+  { pkg: "mvvm-core", description: "Core MVVM library — BaseModel, BaseViewModel, RestfulApiModel, Command, CompositeCommand, ObservableCollection" },
+  { pkg: "query-core", description: "Data fetching and caching — QueryCore, EndpointOptions, CacheProviders" },
+  { pkg: "store-core", description: "Minimal reactive state — createStore, PersistedStore, persistence adapters" },
+  { pkg: "ui-core", description: "Headless UI behaviors — Dialog, Form, ListSelection, RovingFocus, DragDrop, UndoRedo" },
+  { pkg: "forms-core", description: "Framework-agnostic forms — FormFactory, async validation, field dependencies" },
+  { pkg: "plugin-core", description: "Plugin architecture — PluginRegistry, PluginManifest, PluginModule, PluginSDK" },
+  { pkg: "event-bus-core", description: "Pub-sub event bus for cross-feature communication" },
+  { pkg: "http-core", description: "HTTP client utilities and fetch wrappers" },
+  { pkg: "router-core", description: "Framework-agnostic routing utilities" },
+  { pkg: "storage-core", description: "Storage abstraction over localStorage and sessionStorage" },
+  { pkg: "i18n-core", description: "Internationalization utilities" },
+  { pkg: "notifications-core", description: "Notification system" },
+] as const;
+
+type PackageSlug = typeof PACKAGES[number]["pkg"];
+
+async function readDoc(pkg: PackageSlug): Promise<string> {
+  // Resolve from dist/resources/ → up to packages/ → into sibling package
+  const readmePath = join(__dirname, "../../../", pkg, "README.md");
+  try {
+    return await readFile(readmePath, "utf8");
+  } catch {
+    return `# @web-loom/${pkg}\n\nDocumentation not available in this environment. Install the package or run from the web-loom monorepo to access README files.`;
+  }
+}
+
+export function registerDocsResources(server: McpServer): void {
+  for (const { pkg, description } of PACKAGES) {
+    const uri = `web-loom://docs/${pkg}`;
+    server.registerResource(
+      `docs-${pkg}`,
+      uri,
+      { description, mimeType: "text/markdown" },
+      async (_uri) => {
+        const text = await readDoc(pkg as PackageSlug);
+        return { contents: [{ uri, text, mimeType: "text/markdown" }] };
+      }
+    );
+  }
+}

--- a/packages/mcp-server/src/templates/adapter.ts
+++ b/packages/mcp-server/src/templates/adapter.ts
@@ -1,0 +1,144 @@
+export type Framework = "react" | "vue" | "vanilla" | "angular";
+
+export interface AdapterTemplateParams {
+  name: string;
+  framework: Framework;
+}
+
+export function adapterTemplate(p: AdapterTemplateParams): string {
+  const { name, framework } = p;
+  switch (framework) {
+    case "react":
+      return reactAdapterTemplate(name);
+    case "vue":
+      return vueAdapterTemplate(name);
+    case "vanilla":
+      return vanillaAdapterTemplate(name);
+    case "angular":
+      return angularAdapterTemplate(name);
+  }
+}
+
+function reactAdapterTemplate(name: string): string {
+  return `import { useEffect, useState } from "react";
+import type { Observable } from "rxjs";
+import { ${name}Model } from "./${name}Model.js";
+import { ${name}ViewModel } from "./${name}ViewModel.js";
+
+function useObservable<T>(obs: Observable<T>, initial: T): T {
+  const [value, setValue] = useState<T>(initial);
+  useEffect(() => {
+    const sub = obs.subscribe(setValue);
+    return () => sub.unsubscribe();
+  }, [obs]);
+  return value;
+}
+
+export function use${name}() {
+  const [vm] = useState(() => {
+    const model = new ${name}Model();
+    return new ${name}ViewModel(model);
+  });
+
+  const data = useObservable(vm.data$, null);
+  const isLoading = useObservable(vm.isLoading$, false);
+  const error = useObservable(vm.error$, null);
+
+  useEffect(() => {
+    vm.fetchCommand.execute();
+    return () => vm.dispose();
+  }, [vm]);
+
+  return { data, isLoading, error, vm };
+}
+`;
+}
+
+function vueAdapterTemplate(name: string): string {
+  return `import { ref, onMounted, onUnmounted } from "vue";
+import { ${name}Model } from "./${name}Model.js";
+import { ${name}ViewModel } from "./${name}ViewModel.js";
+
+export function use${name}() {
+  const model = new ${name}Model();
+  const vm = new ${name}ViewModel(model);
+
+  const data = ref(null);
+  const isLoading = ref(false);
+  const error = ref(null);
+
+  const subscriptions = [
+    vm.data$.subscribe((v) => { data.value = v; }),
+    vm.isLoading$.subscribe((v) => { isLoading.value = v; }),
+    vm.error$.subscribe((v) => { error.value = v; }),
+  ];
+
+  onMounted(() => { vm.fetchCommand.execute(); });
+  onUnmounted(() => {
+    subscriptions.forEach((s) => s.unsubscribe());
+    vm.dispose();
+  });
+
+  return { data, isLoading, error, vm };
+}
+`;
+}
+
+function vanillaAdapterTemplate(name: string): string {
+  return `import { ${name}Model } from "./${name}Model.js";
+import { ${name}ViewModel } from "./${name}ViewModel.js";
+
+export function create${name}Controller() {
+  const model = new ${name}Model();
+  const vm = new ${name}ViewModel(model);
+
+  const subscriptions = [
+    vm.data$.subscribe((data) => {
+      // TODO: update DOM with data
+      console.log("data:", data);
+    }),
+    vm.isLoading$.subscribe((loading) => {
+      // TODO: show/hide loader
+      console.log("loading:", loading);
+    }),
+    vm.error$.subscribe((err) => {
+      if (err) console.error("error:", err);
+    }),
+  ];
+
+  vm.fetchCommand.execute();
+
+  return {
+    vm,
+    dispose() {
+      subscriptions.forEach((s) => s.unsubscribe());
+      vm.dispose();
+    },
+  };
+}
+`;
+}
+
+function angularAdapterTemplate(name: string): string {
+  return `import { Injectable, OnDestroy } from "@angular/core";
+import { Subscription } from "rxjs";
+import { ${name}Model } from "./${name}Model.js";
+import { ${name}ViewModel } from "./${name}ViewModel.js";
+
+@Injectable()
+export class ${name}Service implements OnDestroy {
+  private readonly _model = new ${name}Model();
+  readonly vm = new ${name}ViewModel(this._model);
+  private readonly _subs = new Subscription();
+
+  constructor() {
+    this.vm.fetchCommand.execute();
+  }
+
+  ngOnDestroy(): void {
+    this._subs.unsubscribe();
+    this.vm.dispose();
+  }
+}
+`;
+}

--- a/packages/mcp-server/src/templates/command.ts
+++ b/packages/mcp-server/src/templates/command.ts
@@ -1,0 +1,68 @@
+export interface CommandTemplateParams {
+  name: string;
+  paramType?: string;
+  resultType?: string;
+  canExecuteLogic?: string;
+  description?: string;
+}
+
+export interface CompositeCommandTemplateParams {
+  name: string;
+  childCommands: string[];
+  mode?: "parallel" | "sequential";
+}
+
+export function commandTemplate(p: CommandTemplateParams): string {
+  const {
+    name,
+    paramType = "void",
+    resultType = "void",
+    canExecuteLogic,
+    description,
+  } = p;
+
+  const paramArg = paramType === "void" ? "" : `param: ${paramType}`;
+  const canExecuteArg = canExecuteLogic
+    ? `,\n  // canExecute: returns Observable<boolean> or boolean\n  ${canExecuteLogic}`
+    : "";
+
+  const descComment = description ? `// ${description}\n` : "";
+
+  return `import { Command } from "@web-loom/mvvm-core";
+
+${descComment}export const ${name} = new Command<${paramType}, ${resultType}>(
+  async (${paramArg}): Promise<${resultType}> => {
+    // TODO: implement
+  }${canExecuteArg}
+);
+
+// Usage:
+// ${name}.execute(${paramType === "void" ? "" : "param"});
+// ${name}.isExecuting$  // Observable<boolean> — use for loading state
+// ${name}.canExecute$   // Observable<boolean> — use to enable/disable UI
+// ${name}.executeError$ // Observable<unknown> — last execution error
+`;
+}
+
+export function compositeCommandTemplate(p: CompositeCommandTemplateParams): string {
+  const { name, childCommands, mode = "parallel" } = p;
+  const registrations = childCommands
+    .map((cmd) => `${name}.register(${cmd});`)
+    .join("\n");
+
+  return `import { CompositeCommand } from "@web-loom/mvvm-core";
+
+export const ${name} = new CompositeCommand({
+  executionMode: "${mode}",
+  monitorCommandActivity: true,
+});
+
+// Register child commands
+${registrations}
+
+// Usage:
+// ${name}.execute();
+// ${name}.isExecuting$  // true while any child runs
+// ${name}.canExecute$   // true when ALL children can execute
+`;
+}

--- a/packages/mcp-server/src/templates/form.ts
+++ b/packages/mcp-server/src/templates/form.ts
@@ -1,0 +1,75 @@
+export interface FormFieldDef {
+  name: string;
+  type: "string" | "number" | "boolean" | "email" | "url";
+  label?: string;
+  required?: boolean;
+  minLength?: number;
+  maxLength?: number;
+}
+
+export interface FormTemplateParams {
+  name: string;
+  fields: FormFieldDef[];
+}
+
+function zodValidation(f: FormFieldDef): string {
+  const validators: string[] = [];
+  if (f.type === "email") validators.push(".email()");
+  if (f.type === "url") validators.push(".url()");
+  if (f.minLength) validators.push(`.min(${f.minLength})`);
+  if (f.maxLength) validators.push(`.max(${f.maxLength})`);
+
+  const baseType =
+    f.type === "boolean"
+      ? "z.boolean()"
+      : f.type === "number"
+        ? "z.number()"
+        : "z.string()";
+  const chain = validators.join("");
+  const full = `${baseType}${chain}`;
+  return f.required === false ? `${full}.optional()` : full;
+}
+
+export function formTemplate(p: FormTemplateParams): string {
+  const { name, fields } = p;
+  const schemaFields = fields
+    .map((f) => `  ${f.name}: ${zodValidation(f)},`)
+    .join("\n");
+
+  const fieldRegistrations = fields
+    .map(
+      (f) =>
+        `  form.registerField("${f.name}", { initialValue: ${f.type === "boolean" ? "false" : f.type === "number" ? "0" : '""'} });`
+    )
+    .join("\n");
+
+  return `import { FormFactory, validateWithZod } from "@web-loom/forms-core";
+import { z } from "zod";
+
+const ${name}FormSchema = z.object({
+${schemaFields}
+});
+
+export type ${name}FormData = z.infer<typeof ${name}FormSchema>;
+
+export const ${name.toLowerCase()}Form = FormFactory.create<${name}FormData>({
+  onSubmit: async (values) => {
+    // TODO: handle form submission
+    console.log("${name} submitted:", values);
+  },
+  validate: (values) => {
+    const result = validateWithZod(${name}FormSchema, values);
+    return result.success ? {} : result.errors ?? {};
+  },
+});
+
+// Register fields
+${fieldRegistrations}
+
+// Usage:
+// ${name.toLowerCase()}Form.setFieldValue("${fields[0]?.name ?? "field"}", value);
+// ${name.toLowerCase()}Form.submit();
+// ${name.toLowerCase()}Form.subscribe((state) => { /* react to changes */ });
+// ${name.toLowerCase()}Form.getState().isValid
+`;
+}

--- a/packages/mcp-server/src/templates/model.ts
+++ b/packages/mcp-server/src/templates/model.ts
@@ -1,0 +1,60 @@
+export interface FieldDef {
+  name: string;
+  type: "string" | "number" | "boolean" | "string[]" | "number[]";
+  optional?: boolean;
+}
+
+export interface ModelTemplateParams {
+  name: string;
+  endpoint: string;
+  fields: FieldDef[];
+  apiBase?: string;
+}
+
+function zodFieldType(f: FieldDef): string {
+  const base: Record<FieldDef["type"], string> = {
+    string: "z.string()",
+    number: "z.number()",
+    boolean: "z.boolean()",
+    "string[]": "z.array(z.string())",
+    "number[]": "z.array(z.number())",
+  };
+  const expr = base[f.type] ?? "z.string()";
+  return f.optional ? `${expr}.optional()` : expr;
+}
+
+export function modelTemplate(p: ModelTemplateParams): string {
+  const { name, endpoint, fields, apiBase = "http://localhost:3000" } = p;
+  const schemaFields = fields
+    .map((f) => `  ${f.name}: ${zodFieldType(f)},`)
+    .join("\n");
+
+  return `import { z } from "zod";
+import { RestfulApiModel } from "@web-loom/mvvm-core";
+
+const ${name}Schema = z.object({
+  id: z.string(),
+${schemaFields}
+});
+
+export type ${name}Data = z.infer<typeof ${name}Schema>;
+export const ${name}ListSchema = z.array(${name}Schema);
+export type ${name}ListData = z.infer<typeof ${name}ListSchema>;
+
+export class ${name}Model extends RestfulApiModel<${name}ListData, typeof ${name}ListSchema> {
+  constructor(apiBase: string = "${apiBase}") {
+    super({
+      baseUrl: apiBase,
+      endpoint: "${endpoint}",
+      fetcher: (url, options) =>
+        fetch(url, options).then((r) => {
+          if (!r.ok) throw new Error(\`HTTP \${r.status}\`);
+          return r.json();
+        }),
+      schema: ${name}ListSchema,
+      initialData: [],
+    });
+  }
+}
+`;
+}

--- a/packages/mcp-server/src/templates/plugin.ts
+++ b/packages/mcp-server/src/templates/plugin.ts
@@ -1,0 +1,79 @@
+export interface PluginRouteParam {
+  path: string;
+  componentName: string;
+}
+
+export interface PluginMenuItemParam {
+  id: string;
+  label: string;
+  icon?: string;
+  path?: string;
+}
+
+export interface PluginTemplateParams {
+  name: string;
+  id: string;
+  displayName?: string;
+  routes?: PluginRouteParam[];
+  menuItems?: PluginMenuItemParam[];
+}
+
+export function pluginTemplate(p: PluginTemplateParams): string {
+  const {
+    name,
+    id,
+    displayName = name,
+    routes = [],
+    menuItems = [],
+  } = p;
+
+  const routeDefs = routes.length
+    ? routes
+        .map(
+          (r) =>
+            `    { path: "${r.path}", component: () => import("./${r.componentName}.js") },`
+        )
+        .join("\n")
+    : "    // No routes defined";
+
+  const menuDefs = menuItems.length
+    ? menuItems
+        .map(
+          (m) =>
+            `    { id: "${m.id}", label: "${m.label}"${m.icon ? `, icon: "${m.icon}"` : ""}${m.path ? `, path: "${m.path}"` : ""} },`
+        )
+        .join("\n")
+    : "    // No menu items defined";
+
+  return `import type { PluginManifest, PluginModule, PluginSDK } from "@web-loom/plugin-core";
+
+export const ${name}Manifest: PluginManifest = {
+  id: "${id}",
+  name: "${displayName}",
+  version: "1.0.0",
+  entry: "@/plugins/${name}/index.js",
+  routes: [
+${routeDefs}
+  ],
+  menuItems: [
+${menuDefs}
+  ],
+  widgets: [],
+  dependencies: [],
+};
+
+export const ${name}Module: PluginModule = {
+  async init(_sdk: PluginSDK): Promise<void> {
+    // Register services, event listeners, etc.
+  },
+
+  async mount(_sdk: PluginSDK): Promise<void> {
+    // Mount plugin UI components
+  },
+
+  async unmount(): Promise<void> {
+    // Cleanup: unsubscribe, remove DOM nodes, etc.
+  },
+};
+`;
+}

--- a/packages/mcp-server/src/templates/viewmodel.ts
+++ b/packages/mcp-server/src/templates/viewmodel.ts
@@ -1,0 +1,54 @@
+export interface CustomCommandDef {
+  name: string;
+  paramType?: string;
+  resultType?: string;
+  description?: string;
+}
+
+export interface ViewModelTemplateParams {
+  name: string;
+  modelClass: string;
+  schemaModule?: string;
+  customCommands?: CustomCommandDef[];
+}
+
+function customCommandBlock(cmd: CustomCommandDef): string {
+  const pType = cmd.paramType ?? "void";
+  const rType = cmd.resultType ?? "void";
+  const executeFn =
+    pType === "void"
+      ? `async () => {\n    // TODO: implement ${cmd.name}\n  }`
+      : `async (_param: ${pType}) => {\n    // TODO: implement ${cmd.name}\n  }`;
+  return `
+  public readonly ${cmd.name} = this.registerCommand(
+    new Command<${pType}, ${rType}>(${executeFn})
+  );`;
+}
+
+export function viewModelTemplate(p: ViewModelTemplateParams): string {
+  const { name, modelClass, schemaModule, customCommands = [] } = p;
+  const schemaMod = schemaModule ?? `./${name}Schema.js`;
+  const modelMod = `./${modelClass}.js`;
+  const hasCustomCommands = customCommands.length > 0;
+  const commandImport = hasCustomCommands
+    ? `import { RestfulApiViewModel, Command } from "@web-loom/mvvm-core";`
+    : `import { RestfulApiViewModel } from "@web-loom/mvvm-core";`;
+
+  const commandBlocks = customCommands.map(customCommandBlock).join("\n");
+
+  return `${commandImport}
+import type { ${name}ListData, ${name}ListSchema } from "${schemaMod}";
+import { ${modelClass} } from "${modelMod}";
+
+export class ${name}ViewModel extends RestfulApiViewModel<${name}ListData, typeof ${name}ListSchema> {${commandBlocks}
+
+  constructor(model: ${modelClass}) {
+    super(model);
+  }
+
+  public override dispose(): void {
+    super.dispose();
+  }
+}
+`;
+}

--- a/packages/mcp-server/src/tools/explain-pattern.ts
+++ b/packages/mcp-server/src/tools/explain-pattern.ts
@@ -1,0 +1,313 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+const PATTERNS: Record<string, string> = {
+  mvvm: `# MVVM Pattern in Web-Loom
+
+MVVM separates concerns into three layers:
+
+**Model** — owns data and API calls. Exposes \`data$\`, \`isLoading$\`, \`error$\` as RxJS observables.
+**ViewModel** — business logic layer. Subscribes to Model observables, creates Commands, exposes derived state for the View.
+**View** — framework-specific UI. Subscribes to ViewModel observables and binds Commands to events.
+
+\`\`\`typescript
+// Model: data layer
+class ProductModel extends RestfulApiModel<ProductData[], typeof ProductListSchema> {
+  constructor() { super({ baseUrl: "...", endpoint: "/products", fetcher, schema: ProductListSchema, initialData: [] }); }
+}
+
+// ViewModel: logic layer
+class ProductViewModel extends RestfulApiViewModel<ProductData[], typeof ProductListSchema> {
+  public readonly activateCommand = this.registerCommand(
+    new Command<string, void>(async (id) => { /* custom logic */ })
+  );
+  constructor(model: ProductModel) { super(model); }
+  public override dispose(): void { super.dispose(); }
+}
+
+// View (React): UI layer
+function ProductList() {
+  const [vm] = useState(() => new ProductViewModel(new ProductModel()));
+  const products = useObservable(vm.data$, []);
+  const loading = useObservable(vm.isLoading$, false);
+  useEffect(() => { vm.fetchCommand.execute(); return () => vm.dispose(); }, [vm]);
+  return loading ? <Spinner /> : products.map(p => <ProductCard key={p.id} product={p} />);
+}
+\`\`\``,
+
+  command: `# Command Pattern in Web-Loom
+
+Commands encapsulate async UI actions with automatic state tracking.
+
+\`\`\`typescript
+import { Command } from "@web-loom/mvvm-core";
+import { map } from "rxjs";
+
+// Basic command
+const submitCommand = new Command<FormData, ApiResponse>(
+  async (data) => {
+    const result = await api.submit(data);
+    return result;
+  },
+  // Optional: canExecute — Observable<boolean> or boolean
+  this.isLoading$.pipe(map(loading => !loading))
+);
+
+// Bind to UI
+submitCommand.isExecuting$   // show spinner
+submitCommand.canExecute$    // disable button
+submitCommand.executeError$  // show error
+await submitCommand.execute(formData);
+\`\`\`
+
+Register inside ViewModels with \`this.registerCommand()\` — this auto-disposes on \`vm.dispose()\`.`,
+
+  observable: `# RxJS Observable Pattern in Web-Loom
+
+Web-Loom uses RxJS BehaviorSubjects internally and exposes read-only Observables to ViewModels and Views.
+
+\`\`\`typescript
+// In Models: BehaviorSubject (mutable)
+private _count$ = new BehaviorSubject<number>(0);
+
+// Exposed to outside: Observable (read-only)
+public get count$(): Observable<number> { return this._count$.asObservable(); }
+
+// In ViewModels: derive new observables
+public readonly doubleCount$ = this.count$.pipe(map(n => n * 2));
+public readonly isPositive$ = this.count$.pipe(map(n => n > 0));
+
+// Combine observables
+public readonly vm$ = combineLatest([this.data$, this.isLoading$]).pipe(
+  map(([data, loading]) => ({ data, loading }))
+);
+\`\`\`
+
+**Key rule**: Always unsubscribe. In ViewModels, use \`this.addSubscription()\` or \`takeUntil(this._destroy$)\`. The dispose pattern handles cleanup.`,
+
+  "dispose-pattern": `# Dispose Pattern in Web-Loom
+
+Every ViewModel holds resources (RxJS subscriptions, Command instances) that must be explicitly released.
+
+\`\`\`typescript
+class MyViewModel extends BaseViewModel<MyModel> {
+  // registerCommand auto-disposes via super.dispose()
+  public readonly saveCommand = this.registerCommand(new Command(...));
+
+  // For manual subscriptions, use addSubscription()
+  constructor(model: MyModel) {
+    super(model);
+    this.addSubscription(
+      this.data$.pipe(
+        filter(Boolean),
+        tap(data => this.onDataLoaded(data))
+      ).subscribe()
+    );
+  }
+
+  public override dispose(): void {
+    super.dispose(); // clears _subscriptions + _registeredCommands + signals _destroy$
+  }
+}
+
+// In React:
+useEffect(() => {
+  return () => vm.dispose(); // run on unmount
+}, [vm]);
+
+// In Vue:
+onUnmounted(() => vm.dispose());
+\`\`\`
+
+Forgetting \`dispose()\` causes memory leaks — subscriptions keep the ViewModel (and its data) alive indefinitely.`,
+
+  plugin: `# Plugin Architecture in Web-Loom
+
+\`\`\`typescript
+import { PluginManifest, PluginModule, PluginRegistry, PluginSDK } from "@web-loom/plugin-core";
+
+// 1. Define manifest (static metadata, declarative)
+const analyticsManifest: PluginManifest = {
+  id: "com.myapp.analytics",
+  name: "Analytics",
+  version: "1.0.0",
+  entry: "@/plugins/analytics/index.js",
+  routes: [{ path: "/analytics", component: () => import("./AnalyticsDashboard.js") }],
+  menuItems: [{ id: "analytics-nav", label: "Analytics", path: "/analytics" }],
+  widgets: [],
+  dependencies: [],
+};
+
+// 2. Define module (runtime lifecycle)
+const analyticsModule: PluginModule = {
+  async init(sdk: PluginSDK) {
+    sdk.events.subscribe("user:action", handler);
+  },
+  async mount(sdk: PluginSDK) {
+    sdk.ui.render(AnalyticsDashboard, document.getElementById("plugin-root")!);
+  },
+  async unmount() {
+    // cleanup DOM, subscriptions
+  },
+};
+
+// 3. Register in host
+const registry = new PluginRegistry();
+registry.register({ ...analyticsManifest, module: analyticsModule });
+\`\`\``,
+
+  store: `# Store Pattern in Web-Loom
+
+\`@web-loom/store-core\` is for **UI-only state** (theme, sidebar visibility, active modal). Business data belongs in Models.
+
+\`\`\`typescript
+import { createStore } from "@web-loom/store-core";
+
+interface UIState {
+  theme: "light" | "dark";
+  sidebarOpen: boolean;
+  activeModal: string | null;
+}
+
+const uiStore = createStore<UIState, UIActions>(
+  { theme: "light", sidebarOpen: true, activeModal: null },
+  (setState) => ({
+    toggleTheme: () =>
+      setState((s) => ({ ...s, theme: s.theme === "light" ? "dark" : "light" })),
+    setSidebar: (open: boolean) =>
+      setState((s) => ({ ...s, sidebarOpen: open })),
+    openModal: (id: string) =>
+      setState((s) => ({ ...s, activeModal: id })),
+    closeModal: () =>
+      setState((s) => ({ ...s, activeModal: null })),
+  })
+);
+
+uiStore.getState();
+uiStore.actions.toggleTheme();
+uiStore.subscribe((state) => console.log(state));
+\`\`\``,
+
+  forms: `# Forms Pattern in Web-Loom
+
+\`\`\`typescript
+import { FormFactory, validateWithZod } from "@web-loom/forms-core";
+import { z } from "zod";
+
+const LoginSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(8),
+});
+
+const loginForm = FormFactory.create<{ email: string; password: string }>({
+  onSubmit: async (values) => {
+    await authService.login(values);
+  },
+  validate: (values) => {
+    const r = validateWithZod(LoginSchema, values);
+    return r.success ? {} : r.errors ?? {};
+  },
+});
+
+loginForm.registerField("email", { initialValue: "" });
+loginForm.registerField("password", { initialValue: "" });
+
+// Subscribe to state
+loginForm.subscribe((state) => {
+  console.log(state.isValid, state.isSubmitting);
+});
+
+// On input change
+loginForm.setFieldValue("email", e.target.value);
+
+// On form submit
+await loginForm.submit();
+\`\`\``,
+
+  query: `# Query Pattern in Web-Loom
+
+\`@web-loom/query-core\` provides stale-while-revalidate caching without a framework.
+
+\`\`\`typescript
+import { QueryCore, InMemoryCacheProvider } from "@web-loom/query-core";
+
+const query = new QueryCore({
+  cacheProvider: new InMemoryCacheProvider(),
+  defaultRefetchAfter: 60_000, // 1 minute
+});
+
+// Define endpoint
+query.defineEndpoint<Product[]>("products", () =>
+  fetch("/api/products").then(r => r.json()),
+  { refetchAfter: 30_000 }
+);
+
+// Subscribe to state changes
+query.subscribe<Product[]>("products", (state) => {
+  // state.data, state.isLoading, state.isError, state.error
+});
+
+// Manual refetch
+await query.refetch("products");
+
+// Invalidate cache
+query.invalidate("products");
+\`\`\`
+
+Prefer \`@web-loom/query-core\` when you need caching and background refetching without the full MVVM stack. Use it inside Models for the data fetching layer.`,
+
+  "composite-command": `# CompositeCommand in Web-Loom
+
+CompositeCommand orchestrates multiple commands as one unit.
+
+\`\`\`typescript
+import { CompositeCommand } from "@web-loom/mvvm-core";
+
+// Parallel: both run at the same time
+const saveAll = new CompositeCommand({ executionMode: "parallel" });
+saveAll.register(saveProfileCommand);
+saveAll.register(saveNotificationsCommand);
+
+// Sequential: runs in registration order
+const onboarding = new CompositeCommand({ executionMode: "sequential" });
+onboarding.register(createAccountCommand);
+onboarding.register(sendWelcomeEmailCommand);
+onboarding.register(setupDefaultsCommand);
+
+await saveAll.execute();  // both profile + notifications save in parallel
+onboarding.isExecuting$   // Observable<boolean>
+onboarding.canExecute$    // true only when ALL children can execute
+\`\`\`
+
+Register composite commands in ViewModels with \`this.registerCommand(saveAll)\` for automatic disposal.`,
+};
+
+export function registerExplainPatternTool(server: McpServer): void {
+  server.registerTool(
+    "explain_pattern",
+    {
+      description: "Get an explanation and code example for a specific web-loom architectural pattern.",
+      inputSchema: {
+        pattern: z
+          .enum([
+            "mvvm",
+            "command",
+            "observable",
+            "dispose-pattern",
+            "plugin",
+            "store",
+            "forms",
+            "query",
+            "composite-command",
+          ])
+          .describe("The pattern to explain"),
+      },
+    },
+    async ({ pattern }) => {
+      const content = PATTERNS[pattern];
+      return {
+        content: [{ type: "text" as const, text: content ?? `Unknown pattern: ${pattern}` }],
+      };
+    }
+  );
+}

--- a/packages/mcp-server/src/tools/list-packages.ts
+++ b/packages/mcp-server/src/tools/list-packages.ts
@@ -1,0 +1,60 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+const PACKAGE_CATALOG = `# @web-loom/* Package Catalog
+
+| Package | Description | Key Exports | When to Use |
+|---------|-------------|-------------|-------------|
+| \`@web-loom/mvvm-core\` | Core MVVM library | \`BaseModel\`, \`RestfulApiModel\`, \`BaseViewModel\`, \`RestfulApiViewModel\`, \`Command\`, \`CompositeCommand\`, \`ObservableCollection\` | Always — the foundation of any web-loom app |
+| \`@web-loom/query-core\` | Data fetching & caching | \`QueryCore\`, \`InMemoryCacheProvider\`, \`LocalStorageCacheProvider\`, \`IndexedDBCacheProvider\` | Need stale-while-revalidate caching, background refetch, or request deduplication |
+| \`@web-loom/store-core\` | Minimal reactive state | \`createStore\`, \`PersistedStore\`, \`MemoryAdapter\`, \`LocalStorageAdapter\`, \`IndexedDBAdapter\` | UI-only state: theme, sidebar open/closed, active modal |
+| \`@web-loom/ui-core\` | Headless UI behaviors | \`createDialogBehavior\`, \`createFormBehavior\`, \`createListSelection\`, \`createRovingFocus\`, \`createDragDropBehavior\`, \`createUndoRedoStack\`, \`createKeyboardShortcuts\` | Accessible, framework-agnostic UI primitives without styling |
+| \`@web-loom/forms-core\` | Framework-agnostic forms | \`FormFactory\`, \`validateWithZod\`, \`AsyncValidator\`, \`FieldDependencyManager\`, \`FieldVisibilityManager\` | Complex forms with async validation, computed fields, or field dependencies |
+| \`@web-loom/plugin-core\` | Plugin architecture | \`PluginRegistry\`, \`PluginManifest\`, \`PluginModule\`, \`PluginSDK\`, \`FrameworkAdapter\` | Extensible apps where third parties add routes, menu items, and widgets |
+| \`@web-loom/event-bus-core\` | Pub-sub event bus | \`EventBus\` | Cross-feature communication without direct coupling between ViewModels |
+| \`@web-loom/http-core\` | HTTP client utilities | Fetch wrappers, interceptors | Consistent HTTP error handling, auth headers, request/response transformations |
+| \`@web-loom/router-core\` | Routing utilities | Route helpers, history abstraction | Framework-agnostic navigation and URL state |
+| \`@web-loom/storage-core\` | Storage abstraction | \`LocalStorageAdapter\`, \`SessionStorageAdapter\` | Decoupled access to browser storage (testable) |
+| \`@web-loom/i18n-core\` | Internationalization | \`I18n\`, translation helpers | Multi-language support |
+| \`@web-loom/notifications-core\` | Notification system | \`NotificationService\` | Toast/alert notifications from ViewModels without direct DOM access |
+| \`@web-loom/platform-core\` | Platform detection | Platform guards | Conditionally run code only on browser or server |
+| \`@web-loom/media-core\` | Media player core | Player state machine, plugin hooks | Audio/video player with extensible plugin hooks |
+| \`@web-loom/forms-react\` | React form adapter | \`useForm\`, React field components | Bind forms-core to React controlled inputs |
+| \`@web-loom/forms-vue\` | Vue form adapter | \`useForm\` composable | Bind forms-core to Vue controlled inputs |
+| \`@web-loom/ui-react\` | React UI adapters | React hooks for ui-core behaviors | Use headless ui-core behaviors as React hooks |
+| \`@web-loom/media-react\` | React media player | \`useMediaPlayer\` | Audio/video player component in React |
+| \`@web-loom/design-core\` | Design tokens & CSS | Theme token utilities | Consistent spacing, color, and typography tokens |
+
+## Minimum Install for a New App
+
+\`\`\`bash
+npm install @web-loom/mvvm-core rxjs zod
+\`\`\`
+
+## Typical App Stack
+
+\`\`\`bash
+# Core MVVM
+npm install @web-loom/mvvm-core @web-loom/query-core rxjs zod
+
+# UI state
+npm install @web-loom/store-core
+
+# Forms (pick your framework adapter)
+npm install @web-loom/forms-core @web-loom/forms-react
+
+# Events
+npm install @web-loom/event-bus-core
+\`\`\`
+`;
+
+export function registerListPackagesTool(server: McpServer): void {
+  server.registerTool(
+    "list_packages",
+    {
+      description: "List all @web-loom/* packages with descriptions, key exports, and guidance on when to use each.",
+    },
+    async () => ({
+      content: [{ type: "text" as const, text: PACKAGE_CATALOG }],
+    })
+  );
+}

--- a/packages/mcp-server/src/tools/scaffold-command.ts
+++ b/packages/mcp-server/src/tools/scaffold-command.ts
@@ -1,0 +1,56 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { commandTemplate, compositeCommandTemplate } from "../templates/command.js";
+
+export function registerScaffoldCommandTool(server: McpServer): void {
+  server.registerTool(
+    "scaffold_command",
+    {
+      description: "Generate a standalone Command<TParam, TResult> or CompositeCommand. Commands encapsulate async actions with built-in isExecuting$, canExecute$, and executeError$ observables.",
+      inputSchema: {
+        name: z.string().describe("Command name (camelCase, e.g. 'exportToCsvCommand')"),
+        paramType: z
+          .string()
+          .optional()
+          .describe("TypeScript type for the execute parameter (default: 'void')"),
+        resultType: z
+          .string()
+          .optional()
+          .describe("TypeScript return type (default: 'void')"),
+        canExecuteLogic: z
+          .string()
+          .optional()
+          .describe(
+            "Optional canExecute expression — an Observable<boolean> or boolean value. Example: 'this.isLoading$.pipe(map(l => !l))'"
+          ),
+        description: z.string().optional().describe("Short description of the command's purpose"),
+        composite: z
+          .object({
+            childCommands: z.array(z.string()).describe("Names of child commands to register"),
+            mode: z.enum(["parallel", "sequential"]).optional(),
+          })
+          .optional()
+          .describe("If set, generates a CompositeCommand instead"),
+      },
+    },
+    async ({ name, paramType, resultType, canExecuteLogic, description, composite }) => {
+      const code = composite
+        ? compositeCommandTemplate({ name, childCommands: composite.childCommands, mode: composite.mode })
+        : commandTemplate({ name, paramType, resultType, canExecuteLogic, description });
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: [
+              `Generated \`${name}\`:\n`,
+              "```typescript",
+              code,
+              "```",
+            ].join("\n"),
+          },
+        ],
+      };
+    }
+  );
+}

--- a/packages/mcp-server/src/tools/scaffold-feature.ts
+++ b/packages/mcp-server/src/tools/scaffold-feature.ts
@@ -1,0 +1,86 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { modelTemplate, type FieldDef } from "../templates/model.js";
+import { viewModelTemplate } from "../templates/viewmodel.js";
+import { adapterTemplate, type Framework } from "../templates/adapter.js";
+
+const FieldSchema = z.object({
+  name: z.string(),
+  type: z.enum(["string", "number", "boolean", "string[]", "number[]"]),
+  optional: z.boolean().optional(),
+});
+
+export function registerScaffoldFeatureTool(server: McpServer): void {
+  server.registerTool(
+    "scaffold_restful_feature",
+    {
+      description: "Generate a complete MVVM feature: Zod schema + RestfulApiModel + RestfulApiViewModel + framework adapter (React hook / Vue composable / vanilla controller / Angular service). Returns a map of file names to file contents.",
+      inputSchema: {
+        name: z
+          .string()
+          .describe("Feature/entity name in PascalCase (e.g. 'Product', 'BlogPost')"),
+        endpoint: z
+          .string()
+          .describe("REST API endpoint (e.g. '/products')"),
+        fields: z
+          .array(FieldSchema)
+          .describe("Entity fields (id is always included automatically)"),
+        framework: z
+          .enum(["react", "vue", "vanilla", "angular"])
+          .describe("Target UI framework for the adapter layer"),
+        apiBase: z
+          .string()
+          .optional()
+          .describe("Base API URL (default: 'http://localhost:3000')"),
+      },
+    },
+    async ({ name, endpoint, fields, framework, apiBase }) => {
+      const typedFields = fields as FieldDef[];
+      const modelCode = modelTemplate({ name, endpoint, fields: typedFields, apiBase });
+      const vmCode = viewModelTemplate({ name, modelClass: `${name}Model` });
+      const adapterCode = adapterTemplate({ name, framework: framework as Framework });
+
+      const adapterFileName =
+        framework === "react"
+          ? `use${name}.ts`
+          : framework === "vue"
+            ? `use${name}.ts`
+            : framework === "angular"
+              ? `${name}.service.ts`
+              : `${name}Controller.ts`;
+
+      const files: Record<string, string> = {
+        [`${name}Model.ts`]: modelCode,
+        [`${name}ViewModel.ts`]: vmCode,
+        [adapterFileName]: adapterCode,
+      };
+
+      const sections = Object.entries(files)
+        .map(([file, code]) => `### \`${file}\`\n\`\`\`typescript\n${code}\`\`\``)
+        .join("\n\n");
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: [
+              `# ${name} Feature — ${framework} adapter\n`,
+              "Create these files in your feature directory:\n",
+              sections,
+              "\n## Setup",
+              "1. Install: `npm install @web-loom/mvvm-core rxjs zod`",
+              `2. Import \`${name}Model\` and \`${name}ViewModel\` from their files`,
+              framework === "react"
+                ? `3. Use the \`use${name}()\` hook in your component`
+                : framework === "vue"
+                  ? `3. Call \`use${name}()\` inside your \`<script setup>\``
+                  : framework === "angular"
+                    ? `3. Provide \`${name}Service\` in your module providers`
+                    : `3. Call \`create${name}Controller()\` and hold the reference`,
+            ].join("\n"),
+          },
+        ],
+      };
+    }
+  );
+}

--- a/packages/mcp-server/src/tools/scaffold-form.ts
+++ b/packages/mcp-server/src/tools/scaffold-form.ts
@@ -1,0 +1,50 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { formTemplate } from "../templates/form.js";
+
+export function registerScaffoldFormTool(server: McpServer): void {
+  server.registerTool(
+    "scaffold_form",
+    {
+      description: "Generate a forms-core form setup with Zod validation schema, field registration, and submit handler. Requires @web-loom/forms-core.",
+      inputSchema: {
+        name: z
+          .string()
+          .describe("Form name in PascalCase (e.g. 'LoginForm', 'ProductCreate')"),
+        fields: z.array(
+          z.object({
+            name: z.string().describe("Field name (camelCase)"),
+            type: z
+              .enum(["string", "number", "boolean", "email", "url"])
+              .describe("Field type (affects Zod validator)"),
+            label: z.string().optional().describe("Human-readable label"),
+            required: z
+              .boolean()
+              .optional()
+              .describe("Whether the field is required (default: true)"),
+            minLength: z.number().optional().describe("Minimum string length"),
+            maxLength: z.number().optional().describe("Maximum string length"),
+          })
+        ),
+      },
+    },
+    async ({ name, fields }) => {
+      const code = formTemplate({ name, fields });
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: [
+              `Generated \`${name.toLowerCase()}Form\` — save as \`${name}Form.ts\`:\n`,
+              "```typescript",
+              code,
+              "```",
+              "\nFor React, subscribe to form state with useEffect or a dedicated hook.",
+              "For Vue, use a ref and subscribe in onMounted.",
+            ].join("\n"),
+          },
+        ],
+      };
+    }
+  );
+}

--- a/packages/mcp-server/src/tools/scaffold-model.ts
+++ b/packages/mcp-server/src/tools/scaffold-model.ts
@@ -1,0 +1,50 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { modelTemplate } from "../templates/model.js";
+
+const FieldSchema = z.object({
+  name: z.string().describe("Field name (camelCase)"),
+  type: z
+    .enum(["string", "number", "boolean", "string[]", "number[]"])
+    .describe("Field type"),
+  optional: z.boolean().optional().describe("Whether the field is optional"),
+});
+
+export function registerScaffoldModelTool(server: McpServer): void {
+  server.registerTool(
+    "scaffold_model",
+    {
+      description: "Generate a RestfulApiModel subclass with a Zod schema for a given entity. Returns TypeScript source code ready to paste into a model file.",
+      inputSchema: {
+        name: z
+          .string()
+          .describe("Entity name in PascalCase (e.g. 'Product', 'UserProfile')"),
+        endpoint: z
+          .string()
+          .describe("REST API endpoint path (e.g. '/products', '/users')"),
+        fields: z.array(FieldSchema).describe("Entity fields (excluding 'id' which is always included)"),
+        apiBase: z
+          .string()
+          .optional()
+          .describe("Base URL for the API (default: 'http://localhost:3000')"),
+      },
+    },
+    async ({ name, endpoint, fields, apiBase }) => {
+      const code = modelTemplate({ name, endpoint, fields, apiBase });
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: [
+              `Generated \`${name}Model\` — save as \`${name}Model.ts\`:\n`,
+              "```typescript",
+              code,
+              "```",
+              `\nNext step: run \`scaffold_viewmodel\` with \`modelClass: "${name}Model"\` to generate the ViewModel.`,
+            ].join("\n"),
+          },
+        ],
+      };
+    }
+  );
+}

--- a/packages/mcp-server/src/tools/scaffold-plugin.ts
+++ b/packages/mcp-server/src/tools/scaffold-plugin.ts
@@ -1,0 +1,68 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { pluginTemplate } from "../templates/plugin.js";
+
+export function registerScaffoldPluginTool(server: McpServer): void {
+  server.registerTool(
+    "scaffold_plugin",
+    {
+      description: "Generate a web-loom plugin — PluginManifest and PluginModule with init/mount/unmount lifecycle hooks. Requires @web-loom/plugin-core.",
+      inputSchema: {
+        name: z
+          .string()
+          .describe("Plugin name in camelCase (e.g. 'analyticsPlugin')"),
+        id: z
+          .string()
+          .describe("Unique plugin identifier (e.g. 'com.myapp.analytics')"),
+        displayName: z
+          .string()
+          .optional()
+          .describe("Human-readable plugin name"),
+        routes: z
+          .array(
+            z.object({
+              path: z.string().describe("Route path (e.g. '/analytics')"),
+              componentName: z.string().describe("Component filename without extension"),
+            })
+          )
+          .optional()
+          .describe("Routes this plugin registers"),
+        menuItems: z
+          .array(
+            z.object({
+              id: z.string(),
+              label: z.string(),
+              icon: z.string().optional(),
+              path: z.string().optional(),
+            })
+          )
+          .optional()
+          .describe("Menu items to add to the host app nav"),
+      },
+    },
+    async ({ name, id, displayName, routes, menuItems }) => {
+      const code = pluginTemplate({ name, id, displayName, routes, menuItems });
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: [
+              `Generated plugin \`${name}\` — save as \`${name}/index.ts\`:\n`,
+              "```typescript",
+              code,
+              "```",
+              "\nRegister in the host app:",
+              "```typescript",
+              `import { PluginRegistry } from "@web-loom/plugin-core";`,
+              `import { ${name}Manifest, ${name}Module } from "./plugins/${name}/index.js";`,
+              "",
+              `const registry = new PluginRegistry();`,
+              `registry.register({ ...${name}Manifest, module: ${name}Module });`,
+              "```",
+            ].join("\n"),
+          },
+        ],
+      };
+    }
+  );
+}

--- a/packages/mcp-server/src/tools/scaffold-viewmodel.ts
+++ b/packages/mcp-server/src/tools/scaffold-viewmodel.ts
@@ -1,0 +1,63 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { viewModelTemplate } from "../templates/viewmodel.js";
+
+const CustomCommandSchema = z.object({
+  name: z.string().describe("Command property name (camelCase, e.g. 'archiveCommand')"),
+  paramType: z
+    .string()
+    .optional()
+    .describe("TypeScript type for the command parameter (default: 'void')"),
+  resultType: z
+    .string()
+    .optional()
+    .describe("TypeScript return type (default: 'void')"),
+  description: z.string().optional().describe("Short description of what the command does"),
+});
+
+export function registerScaffoldViewModelTool(server: McpServer): void {
+  server.registerTool(
+    "scaffold_viewmodel",
+    {
+      description: "Generate a RestfulApiViewModel subclass. Includes built-in fetchCommand, createCommand, updateCommand, deleteCommand from the base class. Add customCommands for any additional actions.",
+      inputSchema: {
+        name: z
+          .string()
+          .describe("Entity name in PascalCase — must match the name used in scaffold_model (e.g. 'Product')"),
+        modelClass: z
+          .string()
+          .describe("Model class name (e.g. 'ProductModel'). The ViewModel will import it from ./{modelClass}.js"),
+        schemaModule: z
+          .string()
+          .optional()
+          .describe("Override the schema import path (default: ./{name}Schema.js)"),
+        customCommands: z
+          .array(CustomCommandSchema)
+          .optional()
+          .describe("Extra commands beyond the built-in CRUD ones"),
+      },
+    },
+    async ({ name, modelClass, schemaModule, customCommands }) => {
+      const code = viewModelTemplate({ name, modelClass, schemaModule, customCommands });
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: [
+              `Generated \`${name}ViewModel\` — save as \`${name}ViewModel.ts\`:\n`,
+              "```typescript",
+              code,
+              "```",
+              "\nBuilt-in commands from `RestfulApiViewModel`:",
+              "- `fetchCommand` — load all items",
+              "- `createCommand` — create a new item",
+              "- `updateCommand` — update by id",
+              "- `deleteCommand` — delete by id",
+              "- `selectedItem$` — currently selected item observable",
+            ].join("\n"),
+          },
+        ],
+      };
+    }
+  );
+}

--- a/packages/mcp-server/src/tools/select-package.ts
+++ b/packages/mcp-server/src/tools/select-package.ts
@@ -1,0 +1,240 @@
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+interface PackageRecommendation {
+  package: string;
+  reason: string;
+  example?: string;
+}
+
+const USE_CASE_MAP: Array<{
+  keywords: string[];
+  recommendations: PackageRecommendation[];
+}> = [
+  {
+    keywords: ["crud", "rest", "api", "fetch", "entity", "list", "model", "viewmodel", "mvvm"],
+    recommendations: [
+      {
+        package: "@web-loom/mvvm-core",
+        reason: "RestfulApiModel handles CRUD HTTP calls; RestfulApiViewModel provides fetchCommand, createCommand, updateCommand, deleteCommand out of the box.",
+        example: "class UserModel extends RestfulApiModel<UserData[], typeof UserListSchema> { ... }",
+      },
+    ],
+  },
+  {
+    keywords: ["cache", "stale", "revalidate", "refetch", "deduplicate", "background refresh"],
+    recommendations: [
+      {
+        package: "@web-loom/query-core",
+        reason: "QueryCore implements stale-while-revalidate caching, background refetch, and request deduplication without a framework.",
+        example: "query.defineEndpoint<User[]>('users', fetcher, { refetchAfter: 30_000 });",
+      },
+    ],
+  },
+  {
+    keywords: ["state", "ui state", "theme", "sidebar", "modal", "panel", "toggle", "global state"],
+    recommendations: [
+      {
+        package: "@web-loom/store-core",
+        reason: "createStore is designed for UI-only state (theme, sidebar, modals). Business data (entities) belongs in Models, not Store.",
+        example: "const uiStore = createStore({ theme: 'light', sidebarOpen: true }, (setState) => ({ toggleTheme: () => setState(s => ({ ...s, theme: s.theme === 'light' ? 'dark' : 'light' })) }));",
+      },
+    ],
+  },
+  {
+    keywords: ["form", "input", "validation", "field", "submit", "dirty", "touched"],
+    recommendations: [
+      {
+        package: "@web-loom/forms-core",
+        reason: "FormFactory.create() handles field lifecycle, Zod validation, async validators, computed fields, and field visibility — framework-agnostic.",
+      },
+      {
+        package: "@web-loom/forms-react",
+        reason: "React adapter for forms-core; provides useForm hook for binding to controlled React inputs.",
+      },
+    ],
+  },
+  {
+    keywords: ["dialog", "modal", "disclosure", "accordion", "keyboard", "focus", "drag", "drop", "undo", "redo", "list selection", "select", "shortcut", "hotkey"],
+    recommendations: [
+      {
+        package: "@web-loom/ui-core",
+        reason: "Headless behavior factories: createDialogBehavior, createDisclosureBehavior, createListSelection, createRovingFocus, createDragDropBehavior, createUndoRedoStack, createKeyboardShortcuts. No styling, no framework deps.",
+      },
+    ],
+  },
+  {
+    keywords: ["plugin", "extension", "addon", "micro-frontend", "route", "menu", "widget", "third party"],
+    recommendations: [
+      {
+        package: "@web-loom/plugin-core",
+        reason: "PluginRegistry manages declarative plugin manifests with routes, menu items, and widgets. PluginModule provides init/mount/unmount lifecycle hooks.",
+      },
+    ],
+  },
+  {
+    keywords: ["event", "publish", "subscribe", "pub sub", "cross feature", "decouple", "broadcast"],
+    recommendations: [
+      {
+        package: "@web-loom/event-bus-core",
+        reason: "EventBus enables cross-feature communication without direct ViewModel-to-ViewModel coupling.",
+      },
+    ],
+  },
+  {
+    keywords: ["storage", "localstorage", "sessionstorage", "persist", "save to disk"],
+    recommendations: [
+      {
+        package: "@web-loom/storage-core",
+        reason: "Storage abstraction that decouples code from direct localStorage/sessionStorage calls — easier to test and swap.",
+      },
+      {
+        package: "@web-loom/store-core",
+        reason: "PersistedStore wraps createStore with automatic persistence via LocalStorageAdapter or IndexedDBAdapter.",
+      },
+    ],
+  },
+  {
+    keywords: ["i18n", "internationalization", "translation", "locale", "language"],
+    recommendations: [
+      {
+        package: "@web-loom/i18n-core",
+        reason: "I18n utilities for managing translations and locale-sensitive formatting.",
+      },
+    ],
+  },
+  {
+    keywords: ["notification", "toast", "alert", "banner", "message", "feedback"],
+    recommendations: [
+      {
+        package: "@web-loom/notifications-core",
+        reason: "NotificationService lets ViewModels trigger user feedback without coupling to DOM or framework.",
+      },
+    ],
+  },
+  {
+    keywords: ["http", "interceptor", "auth header", "request", "response", "middleware"],
+    recommendations: [
+      {
+        package: "@web-loom/http-core",
+        reason: "HTTP client utilities with interceptor support for auth headers, error handling, and request/response transformation.",
+      },
+    ],
+  },
+  {
+    keywords: ["router", "navigation", "route", "url", "history", "redirect"],
+    recommendations: [
+      {
+        package: "@web-loom/router-core",
+        reason: "Framework-agnostic routing utilities for managing navigation state inside ViewModels.",
+      },
+    ],
+  },
+  {
+    keywords: ["media", "video", "audio", "player", "stream"],
+    recommendations: [
+      {
+        package: "@web-loom/media-core",
+        reason: "Media player core with a state machine and plugin extension points.",
+      },
+      {
+        package: "@web-loom/media-react",
+        reason: "React adapter for media-core — provides useMediaPlayer hook.",
+      },
+    ],
+  },
+  {
+    keywords: ["design", "token", "theme", "color", "typography", "spacing", "css"],
+    recommendations: [
+      {
+        package: "@web-loom/design-core",
+        reason: "Design token system and CSS utilities for consistent theming across all web-loom apps.",
+      },
+    ],
+  },
+  {
+    keywords: ["command", "action", "async action", "loading", "executing", "can execute"],
+    recommendations: [
+      {
+        package: "@web-loom/mvvm-core",
+        reason: "Command<TParam, TResult> encapsulates async actions with isExecuting$, canExecute$, and executeError$ observables. CompositeCommand orchestrates multiple commands.",
+        example: "const saveCmd = new Command<FormData, void>(async (data) => { ... });",
+      },
+    ],
+  },
+];
+
+function findRecommendations(useCase: string): PackageRecommendation[] {
+  const lowerCase = useCase.toLowerCase();
+  const found = new Map<string, PackageRecommendation>();
+
+  for (const entry of USE_CASE_MAP) {
+    const matched = entry.keywords.some((kw) => lowerCase.includes(kw));
+    if (matched) {
+      for (const rec of entry.recommendations) {
+        if (!found.has(rec.package)) {
+          found.set(rec.package, rec);
+        }
+      }
+    }
+  }
+
+  return Array.from(found.values());
+}
+
+export function registerSelectPackageTool(server: McpServer): void {
+  server.registerTool(
+    "select_package",
+    {
+      description: "Given a description of what you need to build, recommend the right @web-loom/* package(s) with reasoning.",
+      inputSchema: {
+        use_case: z
+          .string()
+          .describe(
+            "Describe what you're trying to build or the problem you're solving (e.g. 'I need to fetch a list of users from a REST API and display them with loading state')"
+          ),
+      },
+    },
+    async ({ use_case }) => {
+      const recommendations = findRecommendations(use_case);
+
+      if (recommendations.length === 0) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: [
+                "No specific package match found for your use case. Here are general starting points:\n",
+                "- **CRUD entity with REST API**: `@web-loom/mvvm-core` (RestfulApiModel + RestfulApiViewModel)",
+                "- **UI state**: `@web-loom/store-core`",
+                "- **Forms**: `@web-loom/forms-core`",
+                "- **Headless UI behaviors**: `@web-loom/ui-core`",
+                "\nRun `list_packages` to see the full catalog.",
+              ].join("\n"),
+            },
+          ],
+        };
+      }
+
+      const sections = recommendations.map((r) => {
+        const lines = [`### \`${r.package}\``, r.reason];
+        if (r.example) lines.push(`\`\`\`typescript\n${r.example}\n\`\`\``);
+        return lines.join("\n");
+      });
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: [
+              `## Package Recommendations for: "${use_case}"\n`,
+              sections.join("\n\n"),
+              "\n---",
+              "Run `list_packages` for the full catalog or `explain_pattern` for a pattern deep-dive.",
+            ].join("\n"),
+          },
+        ],
+      };
+    }
+  );
+}

--- a/packages/mcp-server/tsconfig.build.json
+++ b/packages/mcp-server/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
+  }
+}

--- a/packages/mcp-server/tsconfig.json
+++ b/packages/mcp-server/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}


### PR DESCRIPTION
MCP server that gives AI assistants structured tools for the web-loom framework — scaffolding, docs, and guided MVVM workflows.

Tools: scaffold_model, scaffold_viewmodel, scaffold_restful_feature, scaffold_command, scaffold_plugin, scaffold_form, explain_pattern, list_packages, select_package

Resources: web-loom://docs/{pkg} (12 packages, live README reads) + web-loom://architecture/mvvm (embedded reference)

Prompts: create-mvvm-feature, debug-viewmodel, migrate-to-web-loom

Includes CI and publish GitHub Actions workflows matching the existing per-package pattern.